### PR TITLE
Fix issues with build on windows. (see #137)

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "sinon": "1.17.7",
     "sinon-chai": "2.8.0",
     "ts-helper": "0.0.1",
-    "ts-node": "2.1.0",
+    "ts-node": "4.1.0",
     "tslint": "4.4.2",
     "tslint-microsoft-contrib": "4.0.0",
     "typescript": "2.3.4"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -20,7 +20,7 @@
   "scripts": {
     "clean": "rimraf lib",
     "lint": "tslint --project=tsconfig.json --config=../../tslint.json --format=prose",
-    "test": "nyc --report-dir=../../target/coverage/core mocha --opts ./mocha.opts 'spec/**/*.spec.*'",
+    "test": "nyc --report-dir=../../target/coverage/core mocha --opts ./mocha.opts \"spec/**/*.spec.*\"",
     "package": "tsc --project tsconfig.json",
     "verify": "npm run clean && npm run lint && npm test && npm run package"
   },

--- a/packages/core/spec/expect.ts
+++ b/packages/core/spec/expect.ts
@@ -3,6 +3,7 @@ import chai = require('chai');
 import sinonChai = require('sinon-chai');
 import chaiAsPromised = require('chai-as-promised');
 import { RecordedActivity, SourceLocation } from '../src/domain/model';
+import {FileUtils} from './file_utils';
 
 chai.use(sinonChai);
 chai.use(chaiAsPromised);
@@ -36,7 +37,7 @@ chai.use(function(chai, utils) {
 
         if (expected_location.path) {
             new Assertion(
-                this._obj.location.path,
+                FileUtils.normalizeToPosixPath(this._obj.location.path),
                 `Expected '${this._obj}' to have been called from ${expected_location.path}, not ${this._obj.location.path}`,
             ).contains(expected_location.path);
         }

--- a/packages/core/spec/file_utils.ts
+++ b/packages/core/spec/file_utils.ts
@@ -1,0 +1,16 @@
+export class FileUtils {
+    static normalizeToPosixPathPromise(pathPromise: Promise<string>): Promise<string> {
+        return pathPromise.then(function(path: string): string {
+            return FileUtils.normalizeToPosixPath(path);
+        });
+    }
+
+    static normalizeToPosixPath(path: string): string {
+        let rootedPath: string = path;
+        const windowsDrivePos: number = path.indexOf(':');
+        if (windowsDrivePos > -1) {
+            rootedPath = path.substring(windowsDrivePos + 1);
+        }
+        return rootedPath.replace(/\\/g, '/');
+    }
+}

--- a/packages/core/spec/io/file_system.spec.ts
+++ b/packages/core/spec/io/file_system.spec.ts
@@ -4,6 +4,7 @@ import * as mockfs from 'mock-fs';
 import { FileSystem } from '../../src/io/file_system';
 
 import expect = require('../expect');
+import {FileUtils} from '../file_utils';
 
 describe ('FileSystem', () => {
 
@@ -31,7 +32,8 @@ describe ('FileSystem', () => {
         it ('tells the absolute path to a JSON file once it is saved', () => {
             const out = new FileSystem(processCWD);
 
-            return expect(out.store('outlet/some.json', JSON.stringify(originalJSON))).to.eventually.equal(`${processCWD}/outlet/some.json`);
+            const filePath: Promise<string> = out.store('outlet/some.json', JSON.stringify(originalJSON));
+            return expect(FileUtils.normalizeToPosixPathPromise(filePath)).to.eventually.equal(`${processCWD}/outlet/some.json`);
         });
 
         it ('complains when provided with an empty path', () => {
@@ -51,7 +53,7 @@ describe ('FileSystem', () => {
             const out = new FileSystem('/sys');
 
             return expect(out.store('dir/file.json', JSON.stringify(originalJSON)))
-                .to.be.eventually.rejectedWith('EACCES, permission denied \'/sys/dir\'');
+                .to.be.eventually.rejectedWith(/EACCES, permission denied '.*[\\/]sys[\\/]dir'/);
         });
 
         it ('complains when provided with an a path to a file that can\'t be overwritten', () => {
@@ -68,7 +70,7 @@ describe ('FileSystem', () => {
             const out = new FileSystem('/sys');
 
             return expect(out.store('file.json', JSON.stringify(originalJSON)))
-                .to.be.eventually.rejectedWith('EACCES, permission denied \'/sys/file.json\'');
+                .to.be.eventually.rejectedWith(/EACCES, permission denied '.*[\\/]sys[\\/]file.json'/);
         });
     });
 
@@ -86,7 +88,8 @@ describe ('FileSystem', () => {
         it ('tells the absolute path to a JSON file once it is saved', () => {
             const out = new FileSystem(processCWD);
 
-            return expect(out.store('outlet/some.png', imageBuffer)).to.eventually.equal(`${processCWD}/outlet/some.png`);
+            const filePath: Promise<string> = out.store('outlet/some.png', imageBuffer);
+            return expect(FileUtils.normalizeToPosixPathPromise(filePath)).to.eventually.equal(`${processCWD}/outlet/some.png`);
         });
 
         it ('complains when provided with an empty path', () => {

--- a/packages/core/spec/reporting/serenity_bdd_reporter.spec.ts
+++ b/packages/core/spec/reporting/serenity_bdd_reporter.spec.ts
@@ -22,6 +22,7 @@ import { Journal, Stage, StageManager } from '../../src/stage';
 import { SerenityBDDReporter, serenityBDDReporter } from '../../src/reporting/serenity_bdd_reporter';
 
 import expect = require('../expect');
+import {FileUtils} from '../file_utils';
 
 describe('When reporting on what happened during the rehearsal', () => {
 
@@ -861,7 +862,11 @@ describe('When reporting on what happened during the rehearsal', () => {
             }
 
             function producedReport(filename: string = '183050024e32d5f68bd5c1f367308f04.json') {
-                return JSON.parse(fs.readFileSync(`${outputDir}/${filename}`).toString('ascii'));
+                const report = JSON.parse(fs.readFileSync(`${outputDir}/${filename}`).toString('ascii'));
+                // TO VERIFY: Added to fix tests on Windows, but is this the best solution? Should the produced report contain OS specific paths or better not (since relative
+                // POSIX paths also work on windows)?
+                report.userStory.path = FileUtils.normalizeToPosixPath(report.userStory.path);
+                return report;
             }
         });
     });

--- a/packages/cucumber-2/package.json
+++ b/packages/cucumber-2/package.json
@@ -24,7 +24,7 @@
   "scripts": {
     "clean": "rimraf lib",
     "lint": "tslint --project=tsconfig.json --config=../../tslint.json --format=prose",
-    "test": "nyc --report-dir=../../target/coverage/cucumber-2 mocha --opts ./mocha.opts 'spec/**/*.spec.*'",
+    "test": "nyc --report-dir=../../target/coverage/cucumber-2 mocha --opts ./mocha.opts \"spec/**/*.spec.*\"",
     "package": "tsc --project tsconfig.json",
     "verify": "npm run clean && npm run lint && npm test && npm run package"
   },

--- a/packages/cucumber/package.json
+++ b/packages/cucumber/package.json
@@ -21,7 +21,7 @@
   "scripts": {
     "clean": "rimraf lib",
     "lint": "tslint --project=tsconfig.json --config=../../tslint.json --format=prose",
-    "test": "nyc --report-dir=../../target/coverage/cucumber mocha --opts ./mocha.opts 'spec/**/*.spec.*'",
+    "test": "nyc --report-dir=../../target/coverage/cucumber mocha --opts ./mocha.opts \"spec/**/*.spec.*\"",
     "package": "tsc --project tsconfig.json",
     "verify": "npm run clean && npm run lint && npm test && npm run package"
   },

--- a/packages/integration-testing/package.json
+++ b/packages/integration-testing/package.json
@@ -17,7 +17,7 @@
   "scripts": {
     "clean": "rimraf lib",
     "lint": "tslint --project=tsconfig.json --config=../../tslint.json --format=prose",
-    "test": "mocha --opts ./mocha.opts 'spec/**/*.spec.*'",
+    "test": "mocha --opts ./mocha.opts \"spec/**/*.spec.*\"",
     "package": "tsc --project tsconfig.json",
     "verify": "npm run clean && npm run lint && npm test && npm run package"
   },

--- a/packages/mocha/package.json
+++ b/packages/mocha/package.json
@@ -21,7 +21,7 @@
   "scripts": {
     "clean": "rimraf lib",
     "lint": "tslint --project=tsconfig.json --config=../../tslint.json --format=prose",
-    "test": "nyc --report-dir=../../target/coverage/mocha mocha --opts ./mocha.opts 'spec/*.spec.ts'",
+    "test": "nyc --report-dir=../../target/coverage/mocha mocha --opts ./mocha.opts \"spec/*.spec.ts\"",
     "package": "tsc --project tsconfig.json",
     "verify": "npm run clean && npm run lint && npm test && npm run package"
   },

--- a/packages/rest/package.json
+++ b/packages/rest/package.json
@@ -24,7 +24,7 @@
   "scripts": {
     "clean": "rimraf lib",
     "lint": "tslint --project=tsconfig.json --config=../../tslint.json --format=prose",
-    "test": "nyc --report-dir=../../target/coverage/rest mocha --opts ./mocha.opts 'spec/**/*.spec.*'",
+    "test": "nyc --report-dir=../../target/coverage/rest mocha --opts ./mocha.opts \"spec/**/*.spec.*\"",
     "package": "tsc --project tsconfig.json",
     "verify": "npm run clean && npm run lint && npm test && npm run package"
   },

--- a/packages/serenity-js/package.json
+++ b/packages/serenity-js/package.json
@@ -28,9 +28,9 @@
     "package": "tsc --project tsconfig-export.json",
     "verify": "npm run clean && npm run lint && npm test && npm run package",
     "rebuild": "npm run clean && npm run verify",
-    "spec:api": "nyc --report-dir=../../target/coverage/api mocha --opts ./mocha.opts 'spec/api/**/*.spec.*'",
+    "spec:api": "nyc --report-dir=../../target/coverage/api mocha --opts ./mocha.opts \"spec/api/**/*.spec.*\"",
     "spec:cookbook": "nyc --report-dir=../../target/coverage/cookbook protractor ./spec/protractor-cookbook.conf.js",
-    "spec:integration": "nyc --report-dir=../../target/coverage/integration mocha --opts ./mocha.opts 'spec/integration/*/*.ts'",
+    "spec:integration": "nyc --report-dir=../../target/coverage/integration mocha --opts ./mocha.opts \"spec/integration/*/*.ts\"",
     "spec": "npm run spec:api && npm run spec:cookbook && npm run spec:integration"
   },
   "peerDependencies": {


### PR DESCRIPTION
Hi Jan,

Here is the pull request containing the fixes I did for building on Windows as discussed in https://github.com/jan-molak/serenity-js/issues/137.

With the update you did to replace nock with axios-mock-adapter, there is only a single test left failing on the 'rest' package:

 1) Interactions delete resource "before each" hook for "should perform as the actor.":
     Error: Timeout of 2000ms exceeded. For async tests and hooks, ensure "done()" is called; if returning a Promise, ensure it resolves.

Still all the protractor tests in 'serenity-js' package are failing. 

I have added the full log of my latest build (from this branch)  in attachment.

Regards,

Luc
[serenity-build.log](https://github.com/jan-molak/serenity-js/files/1626537/serenity-build.log)
