### PR TITLE
Extend Target class to allow nesting a new Target within an existing one

### DIFF
--- a/packages/serenity-js/spec/api/serenity-protractor/screenplay/ui/element_spy_helper.ts
+++ b/packages/serenity-js/spec/api/serenity-protractor/screenplay/ui/element_spy_helper.ts
@@ -1,0 +1,44 @@
+import {ElementArrayFinder, ElementHelper} from 'protractor';
+import {Locator} from 'protractor/built/locators';
+import sinon = require('sinon');
+import {SinonSpy} from 'sinon';
+
+export interface ElementSpyHelper {
+    elementHelper: ElementHelper;
+    elementSpy: SinonSpy;
+    elementAllSpy: SinonSpy;
+}
+
+export class ElementSpyHelperFactory {
+
+    public static createElementSpyHelper(): ElementSpyHelper {
+        const elementFinder: ElementFinder = new ElementFinder();
+        const elementAllSpy = sinon.spy(elementFinder, 'all');
+        const elementSpy = sinon.spy(elementFinder, 'element');
+
+        const elementHelper = ((locator: Locator) => {
+                // Forward call to the ElementFinder mock to make it easy to test the resolver flow
+                elementFinder.element(locator);
+                return elementFinder;
+            }) as ElementHelper;
+
+        elementHelper.all = elementAllSpy;
+
+        return {
+            elementHelper: elementHelper,
+            elementSpy: elementSpy,
+            elementAllSpy: elementAllSpy
+        };
+    };
+}
+
+class ElementFinder {
+    element(locator: Locator): ElementFinder {
+        return this;
+    }
+
+    all(locator: Locator): ElementArrayFinder {
+        return undefined;
+    }
+}
+

--- a/packages/serenity-js/spec/api/serenity-protractor/screenplay/ui/element_spy_helper.ts
+++ b/packages/serenity-js/spec/api/serenity-protractor/screenplay/ui/element_spy_helper.ts
@@ -25,9 +25,9 @@ export class ElementSpyHelperFactory {
         elementHelper.all = elementAllSpy;
 
         return {
-            elementHelper: elementHelper,
-            elementSpy: elementSpy,
-            elementAllSpy: elementAllSpy,
+            elementHelper,
+            elementSpy,
+            elementAllSpy,
         };
     };
 }

--- a/packages/serenity-js/spec/api/serenity-protractor/screenplay/ui/element_spy_helper.ts
+++ b/packages/serenity-js/spec/api/serenity-protractor/screenplay/ui/element_spy_helper.ts
@@ -27,7 +27,7 @@ export class ElementSpyHelperFactory {
         return {
             elementHelper: elementHelper,
             elementSpy: elementSpy,
-            elementAllSpy: elementAllSpy
+            elementAllSpy: elementAllSpy,
         };
     };
 }
@@ -41,4 +41,3 @@ class ElementFinder {
         return undefined;
     }
 }
-

--- a/packages/serenity-js/spec/api/serenity-protractor/screenplay/ui/target_nested.spec.ts
+++ b/packages/serenity-js/spec/api/serenity-protractor/screenplay/ui/target_nested.spec.ts
@@ -1,0 +1,102 @@
+import * as webdriver from 'selenium-webdriver';
+
+import {ElementArrayFinder} from 'protractor';
+import {Locator} from 'protractor/built/locators';
+import {Target} from '../../../../../src/screenplay-protractor';
+import sinon = require('sinon');
+import expect = require('../../../../expect');
+
+describe('Nested target', () => {
+    const
+        grandGrandParentLocator     = webdriver.By.css('div.grand-grand-parent'),
+        grandParentLocator          = webdriver.By.css('div.grand-parent'),
+        parentLocator               = webdriver.By.css('div.parent'),
+        childLocator                = webdriver.By.css('div.child');
+
+    describe ('with one level nesting', () => {
+        const
+            parentTarget     = Target.the('parent').located(parentLocator),
+            childTarget      = Target.within(parentTarget).the('child').located(childLocator);
+
+        it ('can be resolved using protractor `element` resolver', () => {
+            const
+                element          = sinon.spy();
+
+            childTarget.resolveUsing(element);
+
+            expect(element.callCount).to.equal(2);
+            expect(element.getCall(0).args[0]).to.equal(parentLocator);
+            expect(element.getCall(1).args[0]).to.equal(childLocator);
+        });
+
+        it ('can be resolved using protractor `element.all` resolver', () => {
+            const
+                elementFinder   = new ElementFinder(),
+                elementAllResolver  = sinon.spy(elementFinder, 'all'),
+                element          = sinon.spy(ElementFactory(elementFinder));
+
+            childTarget.resolveAllUsing(element);
+
+            expect(element.callCount).to.equal(1);
+            expect(element.getCall(0).args[0]).to.equal(parentLocator);
+            expect(elementAllResolver.getCall(0).args[0]).to.equal(childLocator);
+        });
+    });
+
+    describe ('with deep nesting', () => {
+        const
+            grandGrandParentTarget      = Target.the('grand-grand-parent').located(grandGrandParentLocator),
+            grandParentTarget           = Target.within(grandGrandParentTarget).the('grand-parent').located(grandParentLocator),
+            parentTarget                = Target.within(grandParentTarget).the('parent').located(parentLocator),
+            childTarget                 = Target.within(parentTarget).the('child').located(childLocator);
+
+        it ('can be resolved using protractor `element` resolver', () => {
+            const
+                element          = sinon.spy();
+
+            childTarget.resolveUsing(element);
+
+            expect(element.callCount).to.equal(4);
+            expect(element.getCall(0).args[0]).to.equal(grandGrandParentLocator);
+            expect(element.getCall(1).args[0]).to.equal(grandParentLocator);
+            expect(element.getCall(2).args[0]).to.equal(parentLocator);
+            expect(element.getCall(3).args[0]).to.equal(childLocator);
+        });
+
+        it ('can be resolved using protractor `element.all` resolver', () => {
+            const
+                elementFinder   = new ElementFinder(),
+                elementAllResolver  = sinon.spy(elementFinder, 'all'),
+                elementResolver     = sinon.spy(elementFinder, 'element'),
+                element          = sinon.spy(ElementFactory(elementFinder));
+
+            childTarget.resolveAllUsing(element);
+
+            expect(elementResolver.callCount).to.equal(3);
+            expect(elementAllResolver.callCount).to.equal(1);
+            expect(elementResolver.getCall(0).args[0]).to.equal(grandGrandParentLocator);
+            expect(elementResolver.getCall(1).args[0]).to.equal(grandParentLocator);
+            expect(elementResolver.getCall(2).args[0]).to.equal(parentLocator);
+            expect(elementAllResolver.getCall(0).args[0]).to.equal(childLocator);
+        });
+    });
+
+    const ElementFactory = function(finderSpy: ElementFinder) {
+        return function(locator: Locator) {
+            // Forward call to the ElementFinder mock to make it easy to test the resolver flow
+            finderSpy.element(locator);
+            return finderSpy;
+        };
+    };
+
+    class ElementFinder {
+        element(locator: Locator): ElementFinder {
+            return this;
+        }
+
+        all(locator: Locator): ElementArrayFinder {
+            return undefined;
+        }
+    }
+
+});

--- a/packages/serenity-js/spec/api/serenity-protractor/screenplay/ui/target_nested.spec.ts
+++ b/packages/serenity-js/spec/api/serenity-protractor/screenplay/ui/target_nested.spec.ts
@@ -1,10 +1,8 @@
 import * as webdriver from 'selenium-webdriver';
 
-import {ElementArrayFinder} from 'protractor';
-import {Locator} from 'protractor/built/locators';
 import {Target} from '../../../../../src/screenplay-protractor';
-import sinon = require('sinon');
 import expect = require('../../../../expect');
+import {ElementSpyHelperFactory} from './element_spy_helper';
 
 describe('Nested target', () => {
     const
@@ -20,26 +18,29 @@ describe('Nested target', () => {
 
         it ('can be resolved using protractor `element` resolver', () => {
             const
-                element          = sinon.spy();
+                elementSpyHelper   = ElementSpyHelperFactory.createElementSpyHelper(),
+                element             = elementSpyHelper.elementHelper,
+                elementSpy          = elementSpyHelper.elementSpy;
 
             childTarget.resolveUsing(element);
 
-            expect(element.callCount).to.equal(2);
-            expect(element.getCall(0).args[0]).to.equal(parentLocator);
-            expect(element.getCall(1).args[0]).to.equal(childLocator);
+            expect(elementSpy.callCount).to.equal(2);
+            expect(elementSpy.getCall(0).args[0]).to.equal(parentLocator);
+            expect(elementSpy.getCall(1).args[0]).to.equal(childLocator);
         });
 
         it ('can be resolved using protractor `element.all` resolver', () => {
             const
-                elementFinder   = new ElementFinder(),
-                elementAllResolver  = sinon.spy(elementFinder, 'all'),
-                element          = sinon.spy(ElementFactory(elementFinder));
+                elementSpyHelper   = ElementSpyHelperFactory.createElementSpyHelper(),
+                element             = elementSpyHelper.elementHelper,
+                elementSpy          = elementSpyHelper.elementSpy,
+                elementAllSpy       = elementSpyHelper.elementAllSpy;
 
             childTarget.resolveAllUsing(element);
 
-            expect(element.callCount).to.equal(1);
-            expect(element.getCall(0).args[0]).to.equal(parentLocator);
-            expect(elementAllResolver.getCall(0).args[0]).to.equal(childLocator);
+            expect(elementSpy.callCount).to.equal(1);
+            expect(elementSpy.getCall(0).args[0]).to.equal(parentLocator);
+            expect(elementAllSpy.getCall(0).args[0]).to.equal(childLocator);
         });
     });
 
@@ -52,51 +53,35 @@ describe('Nested target', () => {
 
         it ('can be resolved using protractor `element` resolver', () => {
             const
-                element          = sinon.spy();
+                elementSpyHelper   = ElementSpyHelperFactory.createElementSpyHelper(),
+                element             = elementSpyHelper.elementHelper,
+                elementSpy          = elementSpyHelper.elementSpy;
 
             childTarget.resolveUsing(element);
 
-            expect(element.callCount).to.equal(4);
-            expect(element.getCall(0).args[0]).to.equal(grandGrandParentLocator);
-            expect(element.getCall(1).args[0]).to.equal(grandParentLocator);
-            expect(element.getCall(2).args[0]).to.equal(parentLocator);
-            expect(element.getCall(3).args[0]).to.equal(childLocator);
+            expect(elementSpy.callCount).to.equal(4);
+            expect(elementSpy.getCall(0).args[0]).to.equal(grandGrandParentLocator);
+            expect(elementSpy.getCall(1).args[0]).to.equal(grandParentLocator);
+            expect(elementSpy.getCall(2).args[0]).to.equal(parentLocator);
+            expect(elementSpy.getCall(3).args[0]).to.equal(childLocator);
         });
 
         it ('can be resolved using protractor `element.all` resolver', () => {
             const
-                elementFinder   = new ElementFinder(),
-                elementAllResolver  = sinon.spy(elementFinder, 'all'),
-                elementResolver     = sinon.spy(elementFinder, 'element'),
-                element          = sinon.spy(ElementFactory(elementFinder));
+                elementSpyHelper   = ElementSpyHelperFactory.createElementSpyHelper(),
+                element             = elementSpyHelper.elementHelper,
+                elementSpy          = elementSpyHelper.elementSpy,
+                elementAllSpy       = elementSpyHelper.elementAllSpy;
 
             childTarget.resolveAllUsing(element);
 
-            expect(elementResolver.callCount).to.equal(3);
-            expect(elementAllResolver.callCount).to.equal(1);
-            expect(elementResolver.getCall(0).args[0]).to.equal(grandGrandParentLocator);
-            expect(elementResolver.getCall(1).args[0]).to.equal(grandParentLocator);
-            expect(elementResolver.getCall(2).args[0]).to.equal(parentLocator);
-            expect(elementAllResolver.getCall(0).args[0]).to.equal(childLocator);
+            expect(elementSpy.callCount).to.equal(3);
+            expect(elementAllSpy.callCount).to.equal(1);
+            expect(elementSpy.getCall(0).args[0]).to.equal(grandGrandParentLocator);
+            expect(elementSpy.getCall(1).args[0]).to.equal(grandParentLocator);
+            expect(elementSpy.getCall(2).args[0]).to.equal(parentLocator);
+            expect(elementAllSpy.getCall(0).args[0]).to.equal(childLocator);
         });
     });
-
-    const ElementFactory = function(finderSpy: ElementFinder) {
-        return function(locator: Locator) {
-            // Forward call to the ElementFinder mock to make it easy to test the resolver flow
-            finderSpy.element(locator);
-            return finderSpy;
-        };
-    };
-
-    class ElementFinder {
-        element(locator: Locator): ElementFinder {
-            return this;
-        }
-
-        all(locator: Locator): ElementArrayFinder {
-            return undefined;
-        }
-    }
 
 });


### PR DESCRIPTION
Hi Jan,

The change in this pull request allows nesting a target within an existing one, with no limitation on the nesting depth.

Example:
```
let grandGrandParentTarget = Target.the('grand-grand-parent').located(grandGrandParentLocator);
let grandParentTarget = Target.within(grandGrandParentTarget).the('grand-parent').located(grandParentLocator);
let parentTarget = Target.within(grandParentTarget).the('parent').located(parentLocator);
let childTarget = Target.within(parentTarget).the('child').located(childLocator);
```

The leaf target can be resolved using both the 'element' and 'element.all' resolver. 
All parent targets on its path are resolved using the 'element' resolver.
Maybe it would also be possible to have parents that resolve to multiple elements, but I did not investigate this for now, since what I implemented now is all the functionality that I needed.

Could you please have a look at it?

Regards,

Luc 