### PR TITLE
Added frame switching/handling  functionality

### DIFF
--- a/packages/serenity-js/src/serenity-protractor/screenplay/abilities/browse_the_web.ts
+++ b/packages/serenity-js/src/serenity-protractor/screenplay/abilities/browse_the_web.ts
@@ -121,4 +121,12 @@ export class BrowseTheWeb implements Ability {
             ? maybeTarget.resolveUsing(this.browser.element)
             : maybeTarget;
     }
+
+    switchToFrame(index: number): PromiseLike<void> {
+        return this.browser.switchTo().frame(index);
+    }
+
+    switchToDefaultContent(): PromiseLike<void> {
+        return this.browser.switchTo().defaultContent();
+    }
 }

--- a/packages/serenity-js/src/serenity-protractor/screenplay/interactions/switch.ts
+++ b/packages/serenity-js/src/serenity-protractor/screenplay/interactions/switch.ts
@@ -32,3 +32,14 @@ class SwitchToWindow implements Interaction {
 
     performAs = (actor: UsesAbilities) => BrowseTheWeb.as(actor).switchToWindow(this.handle);
 }
+
+class SwitchToFrame implements Interaction{
+    constructor(private index: number){
+    }
+
+    performAs = (actor : UsesAbilities) => BrowseTheWeb.as(actor).switchToFrame(this.index);
+}
+
+class SwitchToDefaultContent implements Interaction{
+    performAs = (actor : UsesAbilities) => BrowseTheWeb.as(actor).switchToDefaultContent(); 
+}


### PR DESCRIPTION
Currently BrowseTheWeb does not have functions to handle/switch frames, so Added two classes (SwitchToFrame,SwitchToDefaultContent) in switch.ts file and two functions (switchToFrame,switchToDefaultContent) in browse_the_web.ts file