### PR TITLE
feat - add support for SelectedOption, SelectedOptions, SelectedText and SelectedTextItems

### DIFF
--- a/packages/protractor/spec/screenplay/questions/SelectedOption.spec.ts
+++ b/packages/protractor/spec/screenplay/questions/SelectedOption.spec.ts
@@ -1,0 +1,160 @@
+import 'mocha';
+import { Ensure, equals } from '@serenity-js/assertions';
+import { by } from 'protractor';
+import { Navigate, Select, SelectedOption, SelectedOptions, Target, Text } from '../../../src';
+import { pageFromTemplate } from '../../fixtures';
+import { UIActors } from '../../UIActors';
+import { actorCalled, engage } from '@serenity-js/core';
+
+describe('SelectedOption', () => {
+
+    beforeEach(() => engage(new UIActors()));
+
+    class SingleCountry {
+        static Selector = Target.the('country selector').located(by.id('single-option'));
+    }
+
+    /** @test {SelectedOption} */
+    const pageWithSingleSelect = `
+    <html>
+        <body>
+        <form>
+            <fieldset name='options'>
+                <legend>Working with single option</legend>
+                <label for='single-option'>
+                    Country
+                    <select id='single-option'>
+                        <option label='United Kingdom' value='GB' selected='selected'>United Kingdom</option>
+                        <option label='Poland' value='PL' selected='selected'>Poland</option>
+                        <option label='Germany' value='DE' selected='selected'>Germany</option>
+                        <option label='France' value='FR'>France</option>
+                    </select>
+                </label>
+            </fieldset>
+        </form>
+        </body>
+    </html>`;
+    /** @test {SelectedOption.of} */
+    it('should return a single value when a single text argument is passed to Select.option()', () =>
+        actorCalled('Nick').attemptsTo(
+            Navigate.to(pageFromTemplate(pageWithSingleSelect)),
+            Select.option('FR').from(SingleCountry.Selector),
+            Ensure.that(SelectedOption.of(SingleCountry.Selector), equals('FR'))));
+});
+
+describe('SelectedOption', () => {
+
+    beforeEach(() => engage(new UIActors()));
+
+    class SingleCountry {
+        static Selector = Target.the('country selector').located(by.id('single-option'));
+    }
+
+    class TextInput {
+        static Selector = Target.the('country text').located(by.id('country-text'));
+    }
+
+    /** @test {SelectedOption} */
+    const pageWithSingleSelect = `
+    <html>
+        <body>
+        <input>
+            <p id='country-text'>PL</p>
+            <fieldset name='options'>
+                <legend>Working with single option</legend>
+                <label for='single-option'>
+                    Country
+                    <select id='single-option'>
+                        <option label='United Kingdom' value='GB' selected='selected'>United Kingdom</option>
+                        <option label='Poland' value='PL' selected='selected'>Poland</option>
+                        <option label='Germany' value='DE' selected='selected'>Germany</option>
+                        <option label='France' value='FR'>France</option>
+                    </select>
+                </label>
+            </fieldset>
+        </form>
+        </body>
+    </html>`;
+    /** @test {SelectedOption.of} */
+    it('should return a single value when a single answerable argument is passed to Select.option()', () =>
+        actorCalled('Nick').attemptsTo(
+            Navigate.to(pageFromTemplate(pageWithSingleSelect)),
+            Select.option(Text.of(TextInput.Selector)).from(SingleCountry.Selector),
+            Ensure.that(SelectedOption.of(SingleCountry.Selector), equals('PL'))));
+});
+
+describe('SelectedOptions', () => {
+    class MultiCountry {
+        static Selector = Target.the('country selector').located(by.id('multiple-options'));
+    }
+
+    /** @test {SelectedOptions} */
+    const pageWithMultipleSelects = `
+    <html>
+        <body>
+        <form>
+            <fieldset name='options'>
+                <legend>Working with options</legend>
+                <label for='multiple-options'>
+                    Country
+                    <select multiple='' id='multiple-options'>
+                        <option label='United Kingdom' value='GB'>United Kingdom</option>
+                        <option label='Poland' value='PL'>Poland</option>
+                        <option label='Germany' value='DE'>Germany</option>
+                        <option label='France' value='FR'>France</option>
+                    </select>
+                </label>
+            </fieldset>
+        </form>
+        </body>
+    </html>`;
+    /** @test {SelectedOptions.of} */
+    it('should return a multiple values when multiple text arguments are passed to Select', () =>
+        actorCalled('Nick').attemptsTo(
+            Navigate.to(pageFromTemplate(pageWithMultipleSelects)),
+            Select.options(['PL', 'DE']).from(MultiCountry.Selector),
+            Ensure.that(SelectedOptions.of(MultiCountry.Selector), equals(['PL', 'DE']))));
+
+});
+
+describe('SelectedOptions', () => {
+    class MultiCountry {
+        static Selector = Target.the('country selector').located(by.id('multiple-options'));
+    }
+
+    class ListOfItems {
+        static Selector = Target.all('country list').located(by.tagName('li'));
+    }
+
+    /** @test {SelectedOptions} */
+    const pageWithMultipleSelects = `
+    <html>
+        <body>
+        <form>
+            <ul>
+                <li>PL</li>
+                <li>GB</li>
+            </ul>
+            <fieldset name='options'>
+                <legend>Working with options</legend>
+                <label for='multiple-options'>
+                    Country
+                    <select multiple='' id='multiple-options'>
+                        <option label='United Kingdom' value='GB'>United Kingdom</option>
+                        <option label='Poland' value='PL'>Poland</option>
+                        <option label='Germany' value='DE'>Germany</option>
+                        <option label='France' value='FR'>France</option>
+                    </select>
+                </label>
+            </fieldset>
+        </form>
+        </body>
+    </html>`;
+    /** @test {SelectedOptions.of} */
+    it('should return a multiple values when multiple text arguments are passed to Select', () =>
+        actorCalled('Nick').attemptsTo(
+            Navigate.to(pageFromTemplate(pageWithMultipleSelects)),
+            Select.options(Text.ofAll(ListOfItems.Selector)).from(MultiCountry.Selector),
+            Ensure.that(SelectedOptions.of(MultiCountry.Selector), equals(['GB', 'PL']))));
+
+});

--- a/packages/protractor/spec/screenplay/questions/SelectedText.spec.ts
+++ b/packages/protractor/spec/screenplay/questions/SelectedText.spec.ts
@@ -1,0 +1,126 @@
+import 'mocha';
+import { Ensure, equals } from '@serenity-js/assertions';
+import { by } from 'protractor';
+import { Navigate, Select, SelectedText, SelectedTextItems, Target, Text } from '../../../src';
+import { pageFromTemplate } from '../../fixtures';
+import { UIActors } from '../../UIActors';
+import { actorCalled, engage } from '@serenity-js/core';
+
+describe('SelectedText', () => {
+
+    beforeEach(() => engage(new UIActors()));
+
+    class SingleCountry {
+        static Selector = Target.the('country selector').located(by.id('single-option'));
+    }
+
+    /** @test {SelectedText} */
+    const pageWithSingleSelect = `
+    <html>
+        <body>
+        <form>
+            <fieldset name="options">
+                <legend>Working with single option</legend>
+                <label for="single-option">
+                    Country
+                    <select id="single-option">
+                        <option label="United Kingdom" value="GB" selected="selected">United Kingdom</option>
+                        <option label="Poland" value="PL" selected="selected">Poland</option>
+                        <option label="Germany" value="DE" selected="selected">Germany</option>
+                        <option label="France" value="FR">France</option>
+                    </select>
+                </label>
+            </fieldset>
+        </form>
+        </body>
+    </html>`;
+    /** @test {SelectedText.of} */
+    it('should return a single value when a single text item is passed to Select.text()', () =>
+        actorCalled('Nick').attemptsTo(
+            Navigate.to(pageFromTemplate(pageWithSingleSelect)),
+            Select.text('France').from(SingleCountry.Selector),
+            Ensure.that(SelectedText.of(SingleCountry.Selector), equals('France'))));
+
+});
+
+describe('SelectedTextItems', () => {
+
+    beforeEach(() => engage(new UIActors()));
+
+    class MultiCountry {
+        static Selector = Target.the('country selector').located(by.id('multiple-options'));
+    }
+
+    /** @test {SelectedText} */
+    const pageWithMultipleSelects = `
+    <html>
+        <body>
+        <form>
+            <fieldset name="options">
+                <legend>Working with options</legend>
+                <label for="multiple-options">
+                    Country
+                    <select multiple="" id="multiple-options">
+                        <option label="United Kingdom" value="GB">United Kingdom</option>
+                        <option label="Poland" value="PL">Poland</option>
+                        <option label="Germany" value="DE">Germany</option>
+                        <option label="France" value="FR">France</option>
+                    </select>
+                </label>
+            </fieldset>
+        </form>
+        </body>
+    </html>`;
+    /** @test {SelectedText.of} */
+    it('should return a multiple values when an array of text items is passed to Select.textValues()', () =>
+        actorCalled('Nick').attemptsTo(
+            Navigate.to(pageFromTemplate(pageWithMultipleSelects)),
+            Select.textValues(['Poland', 'France']).from(MultiCountry.Selector),
+            Ensure.that(SelectedTextItems.of(MultiCountry.Selector), equals(['Poland', 'France']))));
+
+});
+
+describe('SelectedTextItems', () => {
+
+    beforeEach(() => engage(new UIActors()));
+
+    class MultiCountry {
+        static Selector = Target.the('country selector').located(by.id('multiple-options'));
+    }
+
+    class ListOfItems {
+        static Selector = Target.all('country list').located(by.tagName('li'));
+    }
+
+    /** @test {SelectedText} */
+    const pageWithMultipleSelects = `
+    <html>
+        <body>
+        <form>
+            <ul>
+                <li>Poland</li>
+                <li>Germany</li>
+            </ul>
+            <fieldset name="options">
+                <legend>Working with options</legend>
+                <label for="multiple-options">
+                    Country
+                    <select multiple="" id="multiple-options">
+                        <option label="United Kingdom" value="GB">United Kingdom</option>
+                        <option label="Poland" value="PL">Poland</option>
+                        <option label="Germany" value="DE">Germany</option>
+                        <option label="France" value="FR">France</option>
+                    </select>
+                </label>
+            </fieldset>
+        </form>
+        </body>
+    </html>`;
+    /** @test {SelectedText.of} */
+    it('should return a multiple values when an answerable array of text items is passed to Select.textValues()', () =>
+        actorCalled('Nick').attemptsTo(
+            Navigate.to(pageFromTemplate(pageWithMultipleSelects)),
+            Select.textValues(Text.ofAll(ListOfItems.Selector)).from(MultiCountry.Selector),
+            Ensure.that(SelectedTextItems.of(MultiCountry.Selector), equals(['Poland', 'Germany']))));
+
+});

--- a/packages/protractor/src/screenplay/interactions/Select.ts
+++ b/packages/protractor/src/screenplay/interactions/Select.ts
@@ -1,0 +1,148 @@
+import { Answerable, AnswersQuestions, Question } from '@serenity-js/core';
+import { Interaction, UsesAbilities } from '@serenity-js/core/lib/screenplay';
+import { by, ElementFinder, protractor } from 'protractor';
+import { promiseOf } from '../../promiseOf';
+import { withAnswerOf } from '../withAnswerOf';
+import { RelativeQuestion } from '../questions/RelativeQuestion';
+
+export class Select {
+
+    static option(value: string | Answerable<string>) {
+        return {from: (target: Question<ElementFinder> | ElementFinder): Interaction => new SelectOption(value, target)};
+    }
+
+    static options(values: string[] | Question<Promise<string[]>> & RelativeQuestion<Question<ElementFinder> | ElementFinder, Promise<string[]>>) {
+        return {from: (target: Question<ElementFinder> | ElementFinder): Interaction => new SelectOptions(values, target)};
+    }
+
+    static text(value: string | Answerable<string>) {
+        return {from: (target: Question<ElementFinder> | ElementFinder): Interaction => new SelectText(value, target)};
+    }
+
+    static textValues(values: string[] | Question<Promise<string[]>> & RelativeQuestion<Question<ElementFinder> | ElementFinder, Promise<string[]>>) {
+        return {from: (target: Question<ElementFinder> | ElementFinder): Interaction => new SelectTextValues(values, target)};
+    }
+}
+
+class SelectOption implements Interaction {
+
+    constructor(private value: string | Answerable<string>, private target: Question<ElementFinder> | ElementFinder) {
+    }
+
+    resolveValueAs(actor: UsesAbilities & AnswersQuestions) {
+        if (typeof this.value === "string") {
+            return Promise.resolve(this.value);
+        } else {
+            return actor.answer(this.value);
+        }
+    };
+
+    performAs(actor: UsesAbilities & AnswersQuestions): Promise<void> {
+        return this.resolveValueAs(actor)
+            .then(resolvedValue => {
+                return promiseOf(withAnswerOf(actor, this.target, element => element
+                    .element(by.css(`option[value=${resolvedValue}]`)))
+                    .click());
+            });
+    }
+
+    toString = () => `#actor selects "${this.value}" from ${this.target}`;
+}
+
+class SelectOptions implements Interaction {
+
+    constructor(private values: string[] | Question<Promise<string[]>> & RelativeQuestion<Question<ElementFinder> | ElementFinder, Promise<string[]>>, private target: Question<ElementFinder> | ElementFinder) {
+    }
+
+    resolveValuesAs(actor: AnswersQuestions) {
+        if (Array.isArray(this.values)) {
+            return Promise.resolve(this.values);
+        } else {
+            return actor.answer(this.values);
+        }
+    };
+
+    performAs(actor: UsesAbilities & AnswersQuestions): Promise<void> {
+
+        return this.resolveValuesAs(actor).then(resolvedValues => {
+
+            const hasRequiredValue = (option: ElementFinder) => option.getAttribute('value').then(value => !!~resolvedValues.indexOf(value)),
+                isAlreadySelected = (option: ElementFinder) => option.isSelected(),
+                ensureOnlyOneApplies = (list: boolean[]) => list.filter(_ => _ === true).length === 1,
+                select = (option: ElementFinder) => option.click();
+
+            const optionsToClick = (option: ElementFinder) => protractor.promise.all(
+                [hasRequiredValue(option),
+                    isAlreadySelected(option)]).then(ensureOnlyOneApplies);
+
+            return promiseOf(withAnswerOf(actor, this.target, element => element.all(by.css('option'))
+                .filter(optionsToClick)
+                .each(select)));
+        });
+
+    }
+
+    toString = () => `#actor selects "${this.values}" from ${this.target}`;
+}
+
+class SelectText implements Interaction {
+
+    constructor(private value: string | Answerable<string>, private target: Question<ElementFinder> | ElementFinder) {
+    }
+
+    resolveValueAs(actor: UsesAbilities & AnswersQuestions) {
+        if (typeof this.value === "string") {
+            return Promise.resolve(this.value);
+        } else {
+            return actor.answer(this.value);
+        }
+    };
+
+    performAs(actor: UsesAbilities & AnswersQuestions): Promise<void> {
+        return this.resolveValueAs(actor)
+            .then(resolvedValue => {
+                return promiseOf(withAnswerOf(actor, this.target, element => element
+                    .element(by.cssContainingText('option', resolvedValue)))
+                    .click());
+            });
+    }
+
+    toString = () => `#actor selects "${this.value}" from ${this.target}`;
+}
+
+class SelectTextValues implements Interaction {
+
+    constructor(private values: string[] | Question<Promise<string[]>> & RelativeQuestion<Question<ElementFinder> | ElementFinder, Promise<string[]>>, private target: Question<ElementFinder> | ElementFinder) {
+    }
+
+    resolveValuesAs(actor: AnswersQuestions) {
+        if (Array.isArray(this.values)) {
+            return Promise.resolve(this.values);
+        } else {
+            return actor.answer(this.values);
+        }
+    };
+
+    performAs(actor: UsesAbilities & AnswersQuestions): Promise<void> {
+        return this.resolveValuesAs(actor)
+            .then(resolvedValues => {
+
+                const hasRequiredText = (option: ElementFinder) => option.getText().then(value => !!~resolvedValues.indexOf(value)),
+                    isAlreadySelected = (option: ElementFinder) => option.isSelected(),
+                    ensureOnlyOneApplies = (list: boolean[]) => list.filter(_ => _ === true).length === 1,
+                    select = (option: ElementFinder) => option.click();
+
+                const optionsToClick = (option: ElementFinder) => protractor.promise.all([
+                    hasRequiredText(option),
+                    isAlreadySelected(option),
+                ])
+                    .then(ensureOnlyOneApplies);
+
+                return promiseOf(withAnswerOf(actor, this.target, element => element.all(by.css('option'))
+                    .filter(optionsToClick)
+                    .each(select)));
+            });
+    }
+
+    toString = () => `#actor selects "${this.values}" from ${this.target}`;
+}

--- a/packages/protractor/src/screenplay/interactions/index.ts
+++ b/packages/protractor/src/screenplay/interactions/index.ts
@@ -9,6 +9,7 @@ export * from './Navigate';
 export * from './Press';
 export * from './ResizeBrowserWindow';
 export * from './Scroll';
+export * from './Select';
 export * from './TakeScreenshot';
 export * from './UseAngular';
 export * from './Wait';

--- a/packages/protractor/src/screenplay/questions/SelectedOption.ts
+++ b/packages/protractor/src/screenplay/questions/SelectedOption.ts
@@ -1,0 +1,34 @@
+import { AnswersQuestions, Question, UsesAbilities } from '@serenity-js/core';
+import { ElementFinder } from 'protractor';
+import { promiseOf } from '../../promiseOf';
+import { withAnswerOf } from '../withAnswerOf';
+
+export class SelectedOption implements Question<Promise<string>> {
+  static of = (target: Question<ElementFinder> | ElementFinder) => new SelectedOption(target);
+
+  constructor(private target: Question<ElementFinder> | ElementFinder) {
+  }
+
+  answeredBy(actor: AnswersQuestions & UsesAbilities): Promise<string> {
+    return promiseOf(withAnswerOf(actor, this.target, element => element.$('option:checked').getAttribute('value')));
+  }
+
+  toString = () => `the selected value of ${this.target}`;
+}
+
+export class SelectedOptions implements Question<Promise<string[]>> {
+  static of(target: Question<ElementFinder> | ElementFinder) {
+    return new SelectedOptions(target);
+  }
+
+  constructor(private target: Question<ElementFinder> | ElementFinder) {
+  }
+
+  answeredBy(actor: AnswersQuestions & UsesAbilities): Promise<string[]> {
+    return promiseOf(withAnswerOf(actor, this.target, element => element.$$('option')
+        .filter(option => option.isSelected())
+        .map(values => values.getAttribute('value'))));
+  }
+
+  toString = () => `the selected values of ${this.target}`;
+}

--- a/packages/protractor/src/screenplay/questions/SelectedText.ts
+++ b/packages/protractor/src/screenplay/questions/SelectedText.ts
@@ -1,0 +1,36 @@
+import { AnswersQuestions, Question, UsesAbilities } from '@serenity-js/core';
+import { ElementFinder } from 'protractor';
+import { promiseOf } from '../../promiseOf';
+import { withAnswerOf } from '../withAnswerOf';
+
+export class SelectedText implements Question<Promise<string>> {
+    static of(target: Question<ElementFinder> | ElementFinder) {
+        return new SelectedText(target);
+    }
+
+    constructor(private target: Question<ElementFinder> | ElementFinder) {
+    }
+
+    answeredBy(actor: AnswersQuestions & UsesAbilities): Promise<string> {
+        return promiseOf(withAnswerOf(actor, this.target, element => element.$('option:checked').getText()));
+    }
+
+    toString = () => `the selected visible text of ${this.target}`;
+}
+
+export class SelectedTextItems implements Question<Promise<string[]>> {
+    static of(target: Question<ElementFinder> | ElementFinder) {
+        return new SelectedTextItems(target);
+    }
+
+    constructor(private target: Question<ElementFinder> | ElementFinder) {
+    }
+
+    answeredBy(actor: AnswersQuestions & UsesAbilities): Promise<string[]> {
+        return promiseOf(withAnswerOf(actor, this.target, element => element.$$('option')
+            .filter(option => option.isSelected())
+            .map(elements => elements.getText())));
+    }
+
+    toString = () => `the selected visible text items of ${this.target}`;
+}

--- a/packages/protractor/src/screenplay/questions/index.ts
+++ b/packages/protractor/src/screenplay/questions/index.ts
@@ -5,6 +5,8 @@ export * from './CSSClasses';
 export * from './LastScriptExecution';
 export { Pick } from './Pick';
 export { Target } from './targets';
+export * from './SelectedOption';
+export * from './SelectedText';
 export * from './text';
 export * from './Value';
 export * from './Website';


### PR DESCRIPTION
Hi @jan-molak - I've done this PR as pretty much a carbon copy of 1.x, however on review of the functionality, I've realised it only addresses the Select 'visible text' selection and assertion, not the 'value'. I think this is potentially confusing vocabulary and maybe I should go more down the road of using the vocabulary in [the serenity book section 'working with dropdowns'](https://serenity-bdd.github.io/theserenitybook/latest/screenplay-selenium-tasks.html#_working_with_dropdowns)? So we could have for values:

```
SelectFromOptions.byValues('PL', 'FR').from(MultiCountry.Selector),
Ensure.that(SelectedValues.of(MultiCountry.Selector), equals(['PL', 'FR'])))
```

Then for text:

```
SelectFromOptions.byVisibleText('Poland', 'France').from(MultiCountry.Selector),
Ensure.that(SelectedVisibleText.of(MultiCountry.Selector), equals(['Poland', 'France'])))
```

What do you think?