### PR TITLE
Too little padding on longer scenario names

### DIFF
--- a/packages/console-reporter/src/stage/crew/console-reporter/SummaryFormatter.ts
+++ b/packages/console-reporter/src/stage/crew/console-reporter/SummaryFormatter.ts
@@ -27,9 +27,9 @@ export class SummaryFormatter {
             this.theme.heading('Execution Summary'),
             '',
             ...categoryNames.map(categoryName => {
-                const displayName = categoryName.length > maxCategoryNameLengthAllowed
+                const displayName = (categoryName.length > maxCategoryNameLengthAllowed
                     ? categoryName.substring(0, maxCategoryNameLengthAllowed - 4) + `...:`
-                    : `${ categoryName }:`.padEnd(maxCategoryNameLengthAllowed + 1);
+                    : `${ categoryName }:`).padEnd(maxCategoryNameLengthAllowed + 1);
 
                 return `${ this.theme.heading(displayName) } ${ this.formatTotalsFor(aggregatedCategories.categories[categoryName]) }`;
             }),


### PR DESCRIPTION
Noticed an issue where longer scenario names were 1 space short of being in line with the longer names in the summary, surrounding the ternary if with brackets and padding both to the same length fixes this issue

Before:
<img width="576" alt="Screenshot 2019-11-29 at 15 38 05" src="https://user-images.githubusercontent.com/18209178/69882369-d932d300-12c7-11ea-8d49-fa992f368d77.png">

After:
<img width="573" alt="Screenshot 2019-11-29 at 16 46 45" src="https://user-images.githubusercontent.com/18209178/69882387-e780ef00-12c7-11ea-8348-63e1cd03929a.png">
