### PR TITLE
Add ability to clear empty input field

### DIFF
--- a/packages/protractor/spec/screenplay/interactions/Clear.spec.ts
+++ b/packages/protractor/spec/screenplay/interactions/Clear.spec.ts
@@ -14,6 +14,24 @@ describe('Clear', () => {
 
     /** @test {Clear} */
     /** @test {Clear.theValueOf} */
+    it('allows the actor to clear the value of an empty input field', () => actorCalled('Bernie').attemptsTo(
+        Navigate.to(pageFromTemplate(`
+            <html>
+                <body>
+                    <form>
+                        <input type="text" id="field" value="" />
+                    </form>
+                </body>
+            </html>
+        `)),
+
+        Clear.theValueOf(Form.Field),
+
+        Ensure.that(Value.of(Form.Field), equals('')),
+    ));
+
+    /** @test {Clear} */
+    /** @test {Clear.theValueOf} */
     it('allows the actor to clear the value of an input field', () => actorCalled('Bernie').attemptsTo(
         Navigate.to(pageFromTemplate(`
             <html>

--- a/packages/protractor/src/screenplay/interactions/Clear.ts
+++ b/packages/protractor/src/screenplay/interactions/Clear.ts
@@ -27,7 +27,7 @@ export class Clear extends Interaction {
     performAs(actor: UsesAbilities & AnswersQuestions): PromiseLike<void> {
         return withAnswerOf(actor, this.field, (elf: ElementFinder) =>
             elf.getAttribute('value').then(value => {
-                if (! value) {
+                if (value == null) {
                     throw new LogicError(
                         `${ this.capitaliseFirstLetter(this.field.toString()) } doesn't seem to have a 'value' attribute that could be cleared.`,
                     );


### PR DESCRIPTION
I found that Clear.theValueOf didn't have the ability to handle a empty input field, This small change should handle that