### PR TITLE
docs(rest): fixed typo in example

### DIFF
--- a/packages/rest/src/screenplay/interactions/ChangeApiConfig.ts
+++ b/packages/rest/src/screenplay/interactions/ChangeApiConfig.ts
@@ -71,7 +71,7 @@ import { CallAnApi } from '../abilities';
  *      Question.about(`${ name } environment variable`, actor => process.env[var_name]);
  *
  *  actor.attemptsTo(
- *      ChangeApiConfig.header('Authorization', EnvVar('TOKEN')),
+ *      ChangeApiConfig.setHeader('Authorization', EnvVar('TOKEN')),
  *      Send.a(GetRequest.to('/api')),
  *      Ensure.that(LastResponse.status(), equals(200)),
  *  );


### PR DESCRIPTION
fixed typo in Setting a header for all subsequent requests example