### PR TITLE
feat(assertions): add describedAs method on Check task then specific description can be provided to check

### DIFF
--- a/packages/assertions/spec/Check.spec.ts
+++ b/packages/assertions/spec/Check.spec.ts
@@ -94,6 +94,13 @@ describe('Check', () => {
 
         /** @test {Check.whether} */
         /** @test {Check#whether} */
+        it('provides a description of the check when the user provide a specific description by using describedAs method', () => {
+            const description = "#actor checks whether 4 summed with 1 is 5"
+            expect(Check.whether(4 + 1, isIdenticalTo(5)).andIfSo().describedAs(description).toString()).to.equal(description);
+        });
+
+        /** @test {Check.whether} */
+        /** @test {Check#whether} */
         it('provides a description of the check while correctly cleaning the output from new line characters', () => {
             expect(Check.whether({ person: { name: 'Jan' }}, equals({
                 person: {

--- a/packages/assertions/src/Check.ts
+++ b/packages/assertions/src/Check.ts
@@ -65,9 +65,8 @@ export class Check<Actual> extends Task {
      * @param {...@serenity-js/core/lib/screenplay~Activity[]} alternativeActivities
      * @return {@serenity-js/core/lib/screenplay~Task}
      */
-    otherwise(...alternativeActivities: Activity[]): this {
-        this.alternativeActivities = alternativeActivities;
-        return this;
+    otherwise(...alternativeActivities: Activity[]): Check<Actual> {
+        return new Check(this.actual, this.expectation, this.activities, alternativeActivities);
     }
 
     /**

--- a/packages/assertions/src/Check.ts
+++ b/packages/assertions/src/Check.ts
@@ -56,6 +56,7 @@ export class Check<Actual> extends Task {
         private readonly expectation: Expectation<any, Actual>,
         private readonly activities: Activity[],
         private readonly alternativeActivities: Activity[] = [],
+        private description: string = null,
     ) {
         super();
     }
@@ -93,6 +94,12 @@ export class Check<Actual> extends Task {
         );
     }
 
+    describedAs(description: string): this {
+        this.description = description;
+
+        return this;
+    }
+
     /**
      * @desc
      *  Generates a description to be used when reporting this {@link @serenity-js/core/lib/screenplay~Activity}.
@@ -100,6 +107,6 @@ export class Check<Actual> extends Task {
      * @returns {string}
      */
     toString(): string {
-        return formatted `#actor checks whether ${ this.actual } does ${ this.expectation }`;
+        return this.description ?? formatted `#actor checks whether ${ this.actual } does ${ this.expectation }`;
     }
 }

--- a/packages/assertions/src/Check.ts
+++ b/packages/assertions/src/Check.ts
@@ -55,7 +55,7 @@ export class Check<Actual> extends Task {
         private readonly actual: Answerable<Actual>,
         private readonly expectation: Expectation<any, Actual>,
         private readonly activities: Activity[],
-        private readonly alternativeActivities: Activity[] = [],
+        private alternativeActivities: Activity[] = [],
         private description: string = null,
     ) {
         super();
@@ -65,8 +65,9 @@ export class Check<Actual> extends Task {
      * @param {...@serenity-js/core/lib/screenplay~Activity[]} alternativeActivities
      * @return {@serenity-js/core/lib/screenplay~Task}
      */
-    otherwise(...alternativeActivities: Activity[]): Task {
-        return new Check<Actual>(this.actual, this.expectation, this.activities, alternativeActivities);
+    otherwise(...alternativeActivities: Activity[]): this {
+        this.alternativeActivities = alternativeActivities;
+        return this;
     }
 
     /**


### PR DESCRIPTION
Sometimes using the Check task with direct values on conditions, the description is not clear about what condition the user is really checking for and its purpose. For example:
![image](https://user-images.githubusercontent.com/39963236/107974663-af7dce80-6f95-11eb-9853-7232f5417a31.png)

Who is reading the report can have doubts about why the actor verifies that 0 is greater than 0. It makes no sense to whose are reading.

In that cases, I believe the user can provide specific descriptions to Check task as the example below:

![image](https://user-images.githubusercontent.com/39963236/107986539-0fcb3b00-6fab-11eb-906c-f0697e1b72fa.png)

...and how it appears on the test report:

![image](https://user-images.githubusercontent.com/39963236/107986981-ef4fb080-6fab-11eb-94fd-45a3a2ebb31b.png)


As an alternative, the user can create a question for every condition, but I believe that will become much more verbose. 


