### PR TITLE
chore: add needed jasmine dependency

### DIFF
--- a/examples/protractor-jasmine-todomvc/package.json
+++ b/examples/protractor-jasmine-todomvc/package.json
@@ -48,6 +48,7 @@
     "npm-failsafe": "^0.4.3",
     "protractor": "^7.0.0",
     "ts-node": "^9.1.1",
-    "typescript": "^4.2.2"
+    "typescript": "^4.2.2",
+    "jasmine": "^3.6.4"
   }
 }


### PR DESCRIPTION
Jasmine dependency is needed in order to run tests in protractor-jasmine-todomvc folder, otherwise ```npm test```: command will fail.
I added current version of jasmine to package.json and tests can be executed without problem