### PR TITLE
docs(contributing.md): added CONTRIBUTING.md to the root folder

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,3 @@
+# Contributing
+
+For contributing guidelines please refer to [contributing section](https://serenity-js.org/contributing.html) at    serenity-js.org


### PR DESCRIPTION
I decided to create a file with a link to just keep it simple. Also, some links (e.g. `runtime dependencies`) do not work in markdown format, so we better just point people to the site.