### PR TITLE
feat: support additional reporters

### DIFF
--- a/packages/jasmine/spec/adapter/JasmineAdapter.spec.ts
+++ b/packages/jasmine/spec/adapter/JasmineAdapter.spec.ts
@@ -105,6 +105,52 @@ describe('JasmineAdapter', () => {
         return result;
     });
 
+    /** @test JasmineAdapter#run */
+    it('A reporter is added by default', async () => {
+
+        const
+            specs  = [];
+
+        const adapter = new JasmineAdapter({}, loader);
+
+        FakeJasmineRunner.topSuite.returns(emptySuite)
+
+        await adapter.load(specs)
+        const result = adapter.run();
+
+        FakeJasmineRunner.instance.complete(true);
+
+        expect(FakeJasmineRunner.instance.addReporter).to.have.been.calledOnce
+
+        return result;
+    });
+
+    /** @test JasmineAdapter#run */
+    it('additional reporters are added when specified in config', async () => {
+
+        const
+            additionalReporter = 'anotherReporter',
+            config = {
+                reporters: [ additionalReporter ],
+            },
+            specs  = [];
+
+        const adapter = new JasmineAdapter(config, loader);
+
+        FakeJasmineRunner.topSuite.returns(emptySuite)
+
+        await adapter.load(specs)
+        const result = adapter.run();
+
+        FakeJasmineRunner.instance.complete(true);
+
+        expect(FakeJasmineRunner.instance.addReporter).to.have.been.calledTwice
+
+        expect(FakeJasmineRunner.instance.addReporter).to.have.been.calledWith(additionalReporter)
+
+        return result;
+    });
+
     describe('when counting the number of scenarios to be executed', () => {
 
         /** @test JasmineAdapter#scenarioCount */

--- a/packages/jasmine/src/adapter/JasmineAdapter.ts
+++ b/packages/jasmine/src/adapter/JasmineAdapter.ts
@@ -80,6 +80,12 @@ export class JasmineAdapter implements TestRunnerAdapter {
         ));
 
         this.runner.addReporter(reporter(this.runner.jasmine));
+
+        if (this.config.reporters){
+            const reporters = this.config.reporters
+            reporters.forEach(reporter =>  this.runner.addReporter(reporter));
+        }
+
         this.runner.configureDefaultReporter(this.config);
 
         this.runner.loadRequires();

--- a/packages/jasmine/src/adapter/JasmineConfig.ts
+++ b/packages/jasmine/src/adapter/JasmineConfig.ts
@@ -81,4 +81,36 @@ export interface JasmineConfig {
      * @see https://jasmine.github.io/api/edge/jasmine#.DEFAULT_TIMEOUT_INTERVAL
      */
     defaultTimeoutInterval?: number;
+
+    /**
+     * @desc
+     *  A list of additional reporters which will be added to the test runner.
+     * 
+     *  Useful for situations like configuring ReportPortal, because you cannot do `jasmine.addReporter()` in the protractor config.
+     * 
+     *  Note: reporters must be instantiated before adding them to the configuration.
+     *
+     * @type {string[] | undefined}
+     * 
+     *  @example <caption>Using ReportPortal with Protractor and Jasmine</caption>
+     *  // protractor.conf.js
+     *  const AgentJasmine = require('@reportportal/agent-js-jasmine')
+     *  const agent = new AgentJasmine(require('./reportportalConf'))
+     *  // ...
+     *  jasmineNodeOpts: {
+     *    ...
+     *    reporters: [ agent.getJasmineReporter() ],
+     *  }
+     *
+     * @example <caption>Using ReportPortal with WebdriverIO and Jasmine</caption>
+     *  // wdio.conf.ts
+     *  const AgentJasmine = require('@reportportal/agent-js-jasmine')
+     *  const agent = new AgentJasmine(require('./reportportalConf'))
+     *  // ...
+     *  jasmineOpts: {
+     *    ...
+     *    reporters: [ agent.getJasmineReporter() ],
+     *  }
+     */
+    reporters?: string[];
 }

--- a/packages/jasmine/src/adapter/JasmineConfig.ts
+++ b/packages/jasmine/src/adapter/JasmineConfig.ts
@@ -85,13 +85,13 @@ export interface JasmineConfig {
     /**
      * @desc
      *  A list of additional reporters which will be added to the test runner.
-     * 
+     *
      *  Useful for situations like configuring ReportPortal, because you cannot do `jasmine.addReporter()` in the protractor config.
-     * 
+     *
      *  Note: reporters must be instantiated before adding them to the configuration.
      *
      * @type {string[] | undefined}
-     * 
+     *
      *  @example <caption>Using ReportPortal with Protractor and Jasmine</caption>
      *  // protractor.conf.js
      *  const AgentJasmine = require('@reportportal/agent-js-jasmine')


### PR DESCRIPTION
# Motivation
When using Serenity/Jasmine, sometimes you might want to add existing third party reporters that are not "serenity standard" but, since you don't have access to the jasmine runner object, you cannot do `jasmine.addReporter(reporter)` in the protractor.conf file.
One practical example is using [ReportPortal's agent for Jasmine](https://github.com/reportportal/agent-js-jasmine), which provides all you need to send test executions to your [ReportPortal](https://reportportal.io/) instance seamlessly.

## Configuring ReportPortalAgent
Assuming you have a reportportal config file called `reportportalConf.js` (see https://github.com/reportportal/agent-js-jasmine#protractor-integration), add the following chunks to your protractor.conf file:

#### Instantiate reporter
```
const AgentJasmine = require('@reportportal/agent-js-jasmine')
const agent = new AgentJasmine(require('./reportportalConf'))
```
.....
#### include the reporter in the jasmine config
```
 jasmineNodeOpts: {
    ...
    additionalReporters: [agent.getJasmineReporter()],
  },
```
....

#### Ensure ReportPortal is notified upon finish
 ```
afterLaunch:() => {
    return agent.getExitPromise();
},
```