### PR TITLE
Better support for Cucumber `rerun`

### DIFF
--- a/integration/cucumber-1-runner/src/adapter.ts
+++ b/integration/cucumber-1-runner/src/adapter.ts
@@ -13,6 +13,7 @@ export = async function (cucumberConfig: CucumberConfig, pathToScenario: Path) {
             ]
         },
         new ModuleLoader(runnerRootDir),
+        new FileSystem(Path.from(runnerRootDir)),
         new TempFileOutput(new FileSystem(Path.from(runnerRootDir))),
     );
 

--- a/integration/cucumber-2-runner/src/adapter.ts
+++ b/integration/cucumber-2-runner/src/adapter.ts
@@ -13,6 +13,7 @@ export = async function (cucumberConfig: CucumberConfig, pathToScenario: Path) {
             ]
         },
         new ModuleLoader(runnerRootDir),
+        new FileSystem(Path.from(runnerRootDir)),
         new TempFileOutput(new FileSystem(Path.from(runnerRootDir))),
     );
 

--- a/integration/cucumber-3-runner/src/adapter.ts
+++ b/integration/cucumber-3-runner/src/adapter.ts
@@ -13,6 +13,7 @@ export = async function (cucumberConfig: CucumberConfig, pathToScenario: Path) {
             ]
         },
         new ModuleLoader(runnerRootDir),
+        new FileSystem(Path.from(runnerRootDir)),
         new TempFileOutput(new FileSystem(Path.from(runnerRootDir))),
     );
 

--- a/integration/cucumber-4-runner/src/adapter.ts
+++ b/integration/cucumber-4-runner/src/adapter.ts
@@ -13,6 +13,7 @@ export = async function (cucumberConfig: CucumberConfig, pathToScenario: Path) {
             ]
         },
         new ModuleLoader(runnerRootDir),
+        new FileSystem(Path.from(runnerRootDir)),
         new TempFileOutput(new FileSystem(Path.from(runnerRootDir))),
     );
 

--- a/integration/cucumber-5-runner/src/adapter.ts
+++ b/integration/cucumber-5-runner/src/adapter.ts
@@ -13,6 +13,7 @@ export = async function (cucumberConfig: CucumberConfig, pathToScenario: Path) {
             ]
         },
         new ModuleLoader(runnerRootDir),
+        new FileSystem(Path.from(runnerRootDir)),
         new TempFileOutput(new FileSystem(Path.from(runnerRootDir))),
     );
 

--- a/integration/cucumber-6-runner/src/adapter.ts
+++ b/integration/cucumber-6-runner/src/adapter.ts
@@ -13,6 +13,7 @@ export = async function (cucumberConfig: CucumberConfig, pathToScenario: Path) {
             ]
         },
         new ModuleLoader(runnerRootDir),
+        new FileSystem(Path.from(runnerRootDir)),
         new TempFileOutput(new FileSystem(Path.from(runnerRootDir))),
     );
 

--- a/packages/core/spec/io/FileSystem.spec.ts
+++ b/packages/core/spec/io/FileSystem.spec.ts
@@ -13,6 +13,42 @@ describe ('FileSystem', () => {
         originalJSON = { name: 'jan' },
         processCWD   = new Path('/Users/jan/projects/serenityjs');
 
+    describe('when checking if a file exists', () => {
+        it('returns false when no file exists at path', () => {
+            const
+                fs = FakeFS.with({
+                    [ processCWD.value ]: FakeFS.Empty_Directory,
+                }),
+                out = new FileSystem(processCWD, fs);
+
+            expect(out.exists(new Path('outlet/some.json'))).to.equal(false);
+        });
+
+        it('returns true when a file exists at path', () => {
+            const
+                fs = FakeFS.with({
+                    [ processCWD.value ]: {
+                        'file.txt': 'content'
+                    },
+                }),
+                out = new FileSystem(processCWD, fs);
+
+            expect(out.exists(new Path('file.txt'))).to.equal(true);
+        });
+
+        it('returns true when a directory exists at path', () => {
+            const
+                fs = FakeFS.with({
+                    [ processCWD.value ]: {
+                        'mydir': FakeFS.Empty_Directory
+                    },
+                }),
+                out = new FileSystem(processCWD, fs);
+
+            expect(out.exists(new Path('mydir'))).to.equal(true);
+        });
+    });
+
     describe ('when storing JSON files', () => {
 
         it ('stores a JSON file in a desired location', () => {

--- a/packages/core/src/io/FileSystem.ts
+++ b/packages/core/src/io/FileSystem.ts
@@ -37,6 +37,10 @@ export class FileSystem {
         return stat(this.root.resolve(relativeOrAbsolutePathToFile).value);
     }
 
+    public exists(relativeOrAbsolutePathToFile: Path): boolean {
+        return this.fs.existsSync(this.root.resolve(relativeOrAbsolutePathToFile).value);
+    }
+
     public remove(relativeOrAbsolutePathToFileOrDirectory: Path): Promise<void> {
         const
             stat = promisify(this.fs.stat),

--- a/packages/cucumber/spec/cli/CucumberCLIAdapter.spec.ts
+++ b/packages/cucumber/spec/cli/CucumberCLIAdapter.spec.ts
@@ -143,10 +143,15 @@ describe('CucumberCLIAdapter', function () {
     async function run(config: CucumberConfig, output: SerenityFormatterOutput): Promise<string> {
         clearRequireCache('steps.ts');
 
-        const adapter = new CucumberCLIAdapter({
-            ...config,
-            require: [ path.resolve(__dirname, 'features/step_definitions/steps.ts') ],
-        }, new LocalModuleLoader(rootDirectory.value), output);
+        const adapter = new CucumberCLIAdapter(
+            {
+                ...config,
+                require: [ path.resolve(__dirname, 'features/step_definitions/steps.ts') ],
+            },
+            new LocalModuleLoader(rootDirectory.value),
+            new FileSystem(rootDirectory),
+            output
+        );
 
         const inspect = stdout.inspect();
 

--- a/packages/cucumber/spec/cli/CucumberOptions.spec.ts
+++ b/packages/cucumber/spec/cli/CucumberOptions.spec.ts
@@ -2,7 +2,7 @@
 import 'mocha';
 
 import { expect } from '@integration/testing-tools';
-import { Version } from '@serenity-js/core/lib/io';
+import { FileSystem, Path, Version } from '@serenity-js/core/lib/io';
 import { given } from 'mocha-testdata';
 
 import { CucumberOptions } from '../../src/cli/CucumberOptions';
@@ -20,7 +20,7 @@ describe('CucumberOptions', () => {
             new Version('5.0.0'),
         ]).
         it('is strict by default', (majorVersion: Version) => {
-            const options = new CucumberOptions({ });
+            const options = new CucumberOptions(dummyFS(), { });
 
             expect(options.isStrict()).to.equal(true);
 
@@ -35,7 +35,7 @@ describe('CucumberOptions', () => {
             new Version('5.0.0'),
         ]).
         it('can be explicitly enabled', (majorVersion: Version) => {
-            const options = new CucumberOptions({ strict: true });
+            const options = new CucumberOptions(dummyFS(), { strict: true });
 
             expect(options.isStrict()).to.equal(true);
 
@@ -50,7 +50,7 @@ describe('CucumberOptions', () => {
             new Version('5.0.0'),
         ]).
         it('can be disabled', (majorVersion: Version) => {
-            const options = new CucumberOptions({ strict: false });
+            const options = new CucumberOptions(dummyFS(), { strict: false });
 
             expect(options.isStrict()).to.equal(false);
 
@@ -65,7 +65,7 @@ describe('CucumberOptions', () => {
             new Version('5.0.0'),
         ]).
         it('can be disabled via cucumberOpts.noStrict', (majorVersion: Version) => {
-            const options = new CucumberOptions({ noStrict: true } as any);
+            const options = new CucumberOptions(dummyFS(), { noStrict: true } as any);
 
             expect(options.isStrict()).to.equal(false);
 
@@ -84,7 +84,7 @@ describe('CucumberOptions', () => {
             new Version('5.0.0'),
         ]).
         it('returns no additional arguments when the config is empty', (majorVersion: Version) => {
-            const options = new CucumberOptions({});
+            const options = new CucumberOptions(dummyFS(), {});
 
             expect(options.asArgumentsForCucumber(majorVersion)).to.deep.equal(['node', 'cucumber-js']);
         });
@@ -95,7 +95,7 @@ describe('CucumberOptions', () => {
         describe('rerun formatter', () => {
 
             it('adds the rerun formatter', () => {
-                const options = new CucumberOptions({
+                const options = new CucumberOptions(dummyFS(), {
                     format: 'rerun=@rerun.txt',
                 });
 
@@ -104,14 +104,25 @@ describe('CucumberOptions', () => {
                 );
             });
 
-            it('appends the @rerun.txt file', () => {
-                const options = new CucumberOptions({
+            it('appends the rerun file', () => {
+                const options = new CucumberOptions(fsWithRerunFile(true), {
                     format: 'rerun=@rerun.txt',
                     rerun: '@rerun.txt'
                 });
 
                 expect(options.asArgumentsForCucumber(new Version('7.0.0'))).to.deep.equal(
                     ['node', 'cucumber-js', '--format', 'rerun=@rerun.txt', '@rerun.txt'],
+                );
+            });
+
+            it('does not append the rerun file when it does not exist', () => {
+                const options = new CucumberOptions(fsWithRerunFile(false), {
+                    format: 'rerun=@rerun.txt',
+                    rerun: '@rerun.txt'
+                });
+
+                expect(options.asArgumentsForCucumber(new Version('7.0.0'))).to.deep.equal(
+                    ['node', 'cucumber-js', '--format', 'rerun=@rerun.txt'],
                 );
             });
         });
@@ -127,7 +138,7 @@ describe('CucumberOptions', () => {
             ];
 
             given(emptyTags).it('ignores empty tags when generating tag expressions (>=2.x)', ({ tags }) => {
-                const options = new CucumberOptions({ tags });
+                const options = new CucumberOptions(dummyFS(), { tags });
 
                 expect(options.asArgumentsForCucumber(new Version('2.0.0'))).to.deep.equal([
                     'node', 'cucumber-js',
@@ -135,7 +146,7 @@ describe('CucumberOptions', () => {
             });
 
             given(emptyTags).it('ignores empty tags when working with Cucumber 1.x', ({ tags }) => {
-                const options = new CucumberOptions({ tags });
+                const options = new CucumberOptions(dummyFS(), { tags });
 
                 expect(options.asArgumentsForCucumber(new Version('2.0.0'))).to.deep.equal([
                     'node', 'cucumber-js',
@@ -147,7 +158,7 @@ describe('CucumberOptions', () => {
                 new Version('3.0.0'),
             ]).
             it('converts a list of tags into a Cucumber expression for Cucumber 2.x and newer', (majorVersion: Version) => {
-                const options = new CucumberOptions({
+                const options = new CucumberOptions(dummyFS(), {
                     tags: [
                         '@smoke-test',
                         '~@wip',
@@ -161,7 +172,7 @@ describe('CucumberOptions', () => {
             });
 
             it('passes the tags individually to Cucumber 1.x', () => {
-                const options = new CucumberOptions({
+                const options = new CucumberOptions(dummyFS(), {
                     tags: [
                         '@smoke-test',
                         '~@wip',
@@ -192,7 +203,7 @@ describe('CucumberOptions', () => {
                 { description: 'colors on',        option: 'colors',       state: true,   expected: '--colors'         },
             ]).
             it('correctly interprets boolean options', ({ option, state, expected }) => {
-                const options = new CucumberOptions({
+                const options = new CucumberOptions(dummyFS(), {
                     [option]: state,
                 });
 
@@ -216,7 +227,7 @@ describe('CucumberOptions', () => {
                 { description: 'colors on',        option: 'no-colors',       state: false, expected: '--colors'         },
             ]).
             it('correctly interprets negated boolean options', ({ option, state, expected }) => {
-                const options = new CucumberOptions({
+                const options = new CucumberOptions(dummyFS(), {
                     [option]: state,
                 });
 
@@ -234,7 +245,7 @@ describe('CucumberOptions', () => {
                 { description: 'name',       option: 'name',       value: [ 'checkout.*', 'smoke.*' ],  expected: [ '--name', 'checkout.*',  '--name', 'smoke.*'  ] },
             ]).
             it('includes any other options', ({ option, value, expected }) => {
-                const options = new CucumberOptions({
+                const options = new CucumberOptions(dummyFS(), {
                     [option]: value,
                 });
 
@@ -253,7 +264,7 @@ describe('CucumberOptions', () => {
                 { description: 'retryTagFilter',    option: 'retryTagFilter',   value: '@flaky',    expected: [ '--retry-tag-filter', '@flaky' ] },
             ]).
             it('converts camelCased options to kebab-case', ({ option, value, expected }) => {
-                const options = new CucumberOptions({
+                const options = new CucumberOptions(dummyFS(), {
                     [option]: value,
                 });
 
@@ -271,7 +282,7 @@ describe('CucumberOptions', () => {
                 { description: 'empty list',        option: 'format',           value: [],          },
             ]).
             it('ignores empty values', ({ option, value }) => {
-                const options = new CucumberOptions({
+                const options = new CucumberOptions(dummyFS(), {
                     [option]: value,
                 });
 
@@ -289,7 +300,7 @@ describe('CucumberOptions', () => {
                 { description: 'string',      option: 'worldParameters',    value: '{"baseUrl":"https://example.org"}'  },
             ]).
             it('ignores empty values', ({ option, value }) => {
-                const options = new CucumberOptions({
+                const options = new CucumberOptions(dummyFS(), {
                     [option]: value,
                 });
 
@@ -300,3 +311,15 @@ describe('CucumberOptions', () => {
         });
     });
 });
+
+function dummyFS(): FileSystem {
+    return fsWithRerunFile(false);
+}
+
+function fsWithRerunFile(hasFile: boolean): FileSystem {
+    return {
+        exists: (relativePath_: Path): boolean => {
+            return hasFile
+        }
+    } as unknown as FileSystem;
+}

--- a/packages/cucumber/src/cli/CucumberCLIAdapter.ts
+++ b/packages/cucumber/src/cli/CucumberCLIAdapter.ts
@@ -1,5 +1,5 @@
 /* istanbul ignore file covered in integration tests */
-import { ModuleLoader, TestRunnerAdapter, Version } from '@serenity-js/core/lib/io';
+import { FileSystem, ModuleLoader, TestRunnerAdapter, Version } from '@serenity-js/core/lib/io';
 import { ExecutionIgnored, ImplementationPending, Outcome } from '@serenity-js/core/lib/model';
 
 import { CucumberConfig } from './CucumberConfig';
@@ -28,9 +28,10 @@ export class CucumberCLIAdapter implements TestRunnerAdapter {
     constructor(
         config: CucumberConfig,
         private readonly loader: ModuleLoader,
+        fileSystem: FileSystem,
         private readonly output: SerenityFormatterOutput,
     ) {
-        this.options = new CucumberOptions(config);
+        this.options = new CucumberOptions(fileSystem, config);
     }
 
     /**

--- a/packages/cucumber/src/cli/CucumberOptions.ts
+++ b/packages/cucumber/src/cli/CucumberOptions.ts
@@ -1,4 +1,4 @@
-import { Version } from '@serenity-js/core/lib/io';
+import { FileSystem, Path, Version } from '@serenity-js/core/lib/io';
 
 import { CucumberConfig } from './CucumberConfig';
 
@@ -6,7 +6,10 @@ import { CucumberConfig } from './CucumberConfig';
  * @private
  */
 export class CucumberOptions {
-    constructor(private readonly config: CucumberConfig) {
+    constructor(
+        private readonly fileSystem: FileSystem,
+        private readonly config: CucumberConfig,
+    ) {
     }
 
     isStrict(): boolean {
@@ -26,7 +29,7 @@ export class CucumberOptions {
                 //  https://github.com/cucumber/cucumber-js/blob/d74bc45ba98132bdd0af62e0e52d1fe9ff017006/src/cli/helpers.js#L15
                 [ 'node', 'cucumber-js' ],
             )
-            .concat(this.config.rerun ?? []);
+            .concat(this.config.rerun && this.fileSystem.exists(Path.from(this.config.rerun)) ? this.config.rerun : []);
     }
 
     private optionToValues<O extends keyof CucumberConfig>(option: O, value: CucumberConfig[O], version: Version): string[] {

--- a/packages/protractor/src/adapter/runner/TestRunnerLoader.ts
+++ b/packages/protractor/src/adapter/runner/TestRunnerLoader.ts
@@ -91,6 +91,6 @@ export class TestRunnerLoader {
             ? new StandardOutput()
             : new TempFileOutput(this.fileSystem);
 
-        return new CucumberCLIAdapter(config.object(), this.moduleLoader, output);
+        return new CucumberCLIAdapter(config.object(), this.moduleLoader, this.fileSystem, output);
     }
 }

--- a/packages/webdriverio/src/adapter/TestRunnerLoader.ts
+++ b/packages/webdriverio/src/adapter/TestRunnerLoader.ts
@@ -73,7 +73,7 @@ export class TestRunnerLoader {
             ? new TempFileOutput(this.fileSystem)
             : new StandardOutput();
 
-        return new CucumberCLIAdapter(cleanedCucumberOptions, this.loader, output);
+        return new CucumberCLIAdapter(cleanedCucumberOptions, this.loader, this.fileSystem, output);
     }
 
     private jasmineAdapter(jasmineOptions: WebdriverIO.JasmineOpts): TestRunnerAdapter {


### PR DESCRIPTION
When `rerun:@rerun.txt` option was specified, it was passed as another argument to Cucumber runner.
This could result with Cucumber complaining about "unknown option '--rerun' "

Additionally, don't pass the rerun file to Cucumber if it doesn't exist to avoid it throwing an error.

fix #971