### PR TITLE
feat(translation): using multilanguage features with Serenity/JS

### DIFF
--- a/packages/core/spec/screenplay/TranslationSwissGermanActor.spec.ts
+++ b/packages/core/spec/screenplay/TranslationSwissGermanActor.spec.ts
@@ -1,0 +1,65 @@
+import 'mocha';
+
+import { expect } from 'chai';
+
+import { contain, Ensure, equals} from '../../../local-server/node_modules/@serenity-js/assertions/lib';
+import { Actor, actorCalled, Cast, engage, Translate, Translation, translationDefaultLocale,Translations } from '../../src';
+import { EnsureSame } from './EnsureSame';
+
+class SwissGermanActors implements Cast {
+    prepare(actor: Actor): Actor {
+        return actor.whoCan(Translate.using([translationOne, translationTwo], 'de_CH'));
+    }
+}
+
+const translationOne = {
+    APPLE: {
+        en_US: 'apple',
+        de_DE: 'Apfel',
+        de_CH: 'Apfel'
+    }
+};
+
+const translationTwo = {
+    HELLO: {
+        en_US: 'Hello!',
+        de_DE: 'Hallo!',
+        de_CH: 'Grüezi!'
+    }
+};
+
+describe('Support translations for a Swiss German actor', () => {
+    beforeEach(() => engage(new SwissGermanActors()));
+
+    it('uses translation', () =>
+        actorCalled('Heidi').attemptsTo(
+            EnsureSame(Translation.to('de_CH').of('APPLE'), 'Apfel'),
+            EnsureSame(Translation.to('de_CH').of('HELLO'), 'Grüezi!'),
+        ));
+
+    it('uses translation with default locale', () =>
+        actorCalled('Heidi').attemptsTo(
+            EnsureSame(Translation.of('APPLE'), 'Apfel'),
+            EnsureSame(Translation.of('HELLO'), 'Grüezi!'),
+        ));
+
+    it('throws an assertion error when actual is not expected', () =>
+        expect(actorCalled('Heidi').attemptsTo(
+            EnsureSame(Translation.to('de_CH').of('APPLE'), 'apple')
+        )).to.be.rejectedWith('Expected Apfel to be the same as apple'));
+
+    it('throws an assertion error if translation string is not provided', () =>
+        expect(actorCalled('Heidi').attemptsTo(
+            EnsureSame(Translation.to('de_CH'), 'apple')
+        )).to.be.rejectedWith('Expected undefined to be the same as apple'));
+
+    it('can translate arrays', () =>
+        actorCalled('Heidi').attemptsTo(
+            Ensure.that(Translations.of(['APPLE', 'HELLO']), contain('Apfel'))
+        ));
+
+    it('get the default locale of actor', () =>
+        actorCalled('Heidi').attemptsTo(
+            Ensure.that('de_CH', equals(translationDefaultLocale()))
+        ));
+});

--- a/packages/core/spec/screenplay/TranslationUSAmericanActor.spec.ts
+++ b/packages/core/spec/screenplay/TranslationUSAmericanActor.spec.ts
@@ -1,0 +1,66 @@
+import 'mocha';
+
+import { expect } from 'chai';
+
+import { Ensure, equals} from '../../../local-server/node_modules/@serenity-js/assertions/lib';
+import { Actor, actorCalled, Cast, engage, Translate, Translation, translationDefaultLocale } from '../../src';
+import { EnsureSame } from './EnsureSame';
+
+class UsAmericanActor implements Cast {
+    prepare(actor: Actor): Actor {
+        return actor.whoCan(Translate.using([translationOne, translationTwo], 'en_US'));
+    }
+}
+
+const translationOne = {
+    APPLE: {
+        en_US: 'apple',
+        de_DE: 'Apfel',
+        de_CH: 'Apfel'
+    }
+};
+
+const translationTwo = {
+    HELLO: {
+        en_US: 'Hello!',
+        de_DE: 'Hallo!',
+        de_CH: 'Grüezi!'
+    }
+};
+
+describe('Multi Language Support / Translations US American Actor', () => {
+    beforeEach(() => engage(new UsAmericanActor()));
+
+    it('uses translations', () =>
+        actorCalled('Travis').attemptsTo(
+            EnsureSame(Translation.to('en_US').of('APPLE'), 'apple'),
+            EnsureSame(Translation.to('en_US').of('HELLO'), 'Hello!'),
+        ));
+
+    it('throws an assertion errror when actual is not expected', () =>
+        expect(actorCalled('Travis').attemptsTo(
+            EnsureSame(Translation.to('en_US').of('APPLE'), 'Apfel')
+        )).to.be.rejectedWith('Expected apple to be the same as Apfel'));
+
+    it('uses translation with default locale', () =>
+        actorCalled('Travis').attemptsTo(
+            EnsureSame(Translation.of('APPLE'), 'apple'),
+            EnsureSame(Translation.of('HELLO'), 'Hello!'),
+        ));
+
+    it('provides a sensible description with default locale', () =>
+        expect(Translation.of('APPLE').toString()).to.equal('translation of APPLE with default locale'));
+
+    it('provides a sensible description with given locale', () =>
+        expect(Translation.to('en_US').of('APPLE').toString()).to.equal('translation of APPLE with locale en_US'));
+
+    it('allows the default description to be overridden', () =>
+        expect(Translation.of('APPLE').describedAs('overriden translation').toString())
+            .to.equal('overriden translation'));
+
+    it('get the default locale of actor Travis', () =>
+        actorCalled('Travis').attemptsTo(
+            Ensure.that('en_US', equals(translationDefaultLocale()))
+        ));
+
+});

--- a/packages/core/src/screenplay/abilities/Translate.ts
+++ b/packages/core/src/screenplay/abilities/Translate.ts
@@ -1,0 +1,35 @@
+import { LogicError } from '../../errors';
+import { formatted } from '../../io';
+import { Ability, AnswersQuestions, UsesAbilities } from '..';
+
+export class Translate implements Ability {
+
+    constructor(dictionaries: Array<unknown>, private readonly deaultLocale: string) {
+        this.translations = new Object();
+        dictionaries.forEach((element) => {
+            this.translations = Object.assign(this.translations, element);
+        });
+    }
+
+    private translations: unknown;
+
+    static as(actor: UsesAbilities & AnswersQuestions): Translate {
+        return actor.abilityTo(Translate);
+    }
+
+    static using(dictionaries: Array<unknown>, locale: string): Translate {
+        return new Translate(dictionaries, locale)
+    }
+
+    answerTo(translationString: string, locale: string): Promise<string> {
+        try {
+            return Promise.resolve(this.translations[translationString][locale] ?? this.translations[translationString][this.deaultLocale]);
+        } catch (error) {
+            Promise.reject(new LogicError(formatted`Translation error for "${translationString}" and locale "${locale}": ${error}`));
+        }
+    }
+
+    answerToDefaultLocale(): Promise<string> {
+        return Promise.resolve(this.deaultLocale);
+    }
+}

--- a/packages/core/src/screenplay/abilities/index.ts
+++ b/packages/core/src/screenplay/abilities/index.ts
@@ -1,3 +1,4 @@
 export * from './Discardable';
 export * from './Initialisable';
 export * from './TakeNotes';
+export * from './Translate';

--- a/packages/core/src/screenplay/questions/Translation.ts
+++ b/packages/core/src/screenplay/questions/Translation.ts
@@ -1,0 +1,42 @@
+import { Answerable, AnswersQuestions, UsesAbilities } from '..';
+import { Translate } from '../abilities/Translate';
+import { Question } from '../Question';
+import { MetaQuestion, translationDefaultLocale } from '.';
+
+export class Translation extends Question<Promise<string>> implements MetaQuestion<Answerable<string>, Promise<string>> {
+
+    private description: string;
+
+    constructor(private readonly translationString: string, private readonly locale?: string) {
+        super();
+        this.description = locale ?
+            `translation of ${this.translationString} with locale ${locale}`
+            : `translation of ${this.translationString} with default locale`;
+    }
+
+    of(translationString: string): Translation {
+        return new Translation(translationString, this.locale);
+    }
+
+    static of(translationString: string): Translation {
+        return new Translation(translationString);
+    }
+
+    toString(): string {
+        return this.description;
+    }
+    describedAs(description: string): this {
+        this.description = description;
+        return this;
+    }
+
+    static to(locale: string): Translation {
+        return new Translation(undefined, locale);
+    }
+
+    answeredBy(actor: AnswersQuestions & UsesAbilities & Translate): Promise<string> {
+        return Translate.as(actor).answerTo(this.translationString, this.locale);
+    }
+
+    static defaultLocale = () : Question<Promise<string>>  => translationDefaultLocale();
+}

--- a/packages/core/src/screenplay/questions/TranslationDefaultLocale.ts
+++ b/packages/core/src/screenplay/questions/TranslationDefaultLocale.ts
@@ -1,0 +1,8 @@
+import { Question } from '..';
+import { Translate } from '../abilities/Translate';
+
+export const translationDefaultLocale = (): Question<Promise<string>> =>
+    Question.about('the current default locale for translations', (actor) =>
+        Translate.as(actor).answerToDefaultLocale()
+    );
+

--- a/packages/core/src/screenplay/questions/Translations.ts
+++ b/packages/core/src/screenplay/questions/Translations.ts
@@ -1,0 +1,44 @@
+import { Answerable, AnswersQuestions, UsesAbilities } from '..';
+import { Translate } from '../abilities/Translate';
+import { Question } from '../Question';
+import { MetaQuestion, translationDefaultLocale } from '.';
+
+export class Translations extends Question<Promise<string[]>> implements MetaQuestion<Answerable<string[]>, Promise<string[]>> {
+
+    private description: string;
+
+    constructor(private readonly translationStrings: string[], private readonly locale?: string) {
+        super();
+        this.description = locale ?
+            `translation of ${this.translationStrings} with locale ${locale}`
+            : `translation of ${this.translationStrings} with default locale`;
+    }
+
+    of(translationStrings: string[]): Translations {
+        return new Translations(translationStrings, this.locale);
+    }
+
+    static of(translationStrings: string[]): Translations {
+        return new Translations(translationStrings);
+    }
+
+    toString(): string {
+        return this.description;
+    }
+    describedAs(description: string): this {
+        this.description = description;
+        return this;
+    }
+
+    static to(locale: string): Translations {
+        return new Translations(undefined, locale);
+    }
+
+    async answeredBy(actor: AnswersQuestions & UsesAbilities & Translate): Promise<string[]> {
+        const elements: string[] =
+            await Promise.all(this.translationStrings.map(item => Translate.as(actor).answerTo(item, this.locale)));
+        return elements;
+    }
+
+    static defaultLocale = () : Question<Promise<string>>  => translationDefaultLocale();
+}

--- a/packages/core/src/screenplay/questions/index.ts
+++ b/packages/core/src/screenplay/questions/index.ts
@@ -5,3 +5,6 @@ export * from './List';
 export * from './MetaQuestion';
 export * from './Note';
 export * from './q';
+export * from './Translation';
+export * from './TranslationDefaultLocale';
+export * from './Translations';


### PR DESCRIPTION
This PR is just meant to start a discussion about this topic.

My main use case is having an application that supports multiple user languages. While the use cases stay the same, we have to locate page elements by a text in a different language or ensure, that the text of a page element is displayed in the right language. 

Until now I have a `translateTo` function which takes an array of objects like 

```ts
Const customTranslations = {
  SAVE: {
	En_Us: “Save”,
	De_Ch: “Speichern”,
	Fr_Ch: “Enregistrer”
   }
}
```

(See Gitter discussions, https://gitter.im/serenity-js/Lobby?at=611662b9f31bc0605a5e25b0)

I have a global configuration file, where the global locale for all test runs is set. But the requirement is to be able to set another locale for a certain test spec only, as well. (At the moment, this is just a simple reset of the locale from the global config object within the spec.)

Normally I’d put my `Task`s and `PageElements` into classes. I try to separate my tests:

- In my specs I just use `Task`s that are imported from my `Task` classes. I try not to import any `PageElements` into the spec files directly.
- In my `Task` classes  I import from the `PageElement` classes.

Having the requirement to be able to change the locale from a certain test spec (and for this test spec only) I have to “inject” the locale into the `Task` class constructors and then into the `PageElements` class constructors as well and init the `translateTo` function with the right locale (and set of translation objects).

Hence, I cannot really use static `PageElements` or constants as this translate object has to be initialised each time before I can use it in a locator strategy like `.where(Text, t(‘SAVE’))` for example.

So every time I have to import from a `Task` class in my specs I have to create a new instance in of it, what could become quite nasty when importing from more classes. Every time I write a new `Task` or `PageElement` class I have to ensure, that the translate object is initialised.

I tried to think my use case the Serenity/JS way. Isn’t it the `Ability` of an `Actor` to `SpeakALanguage`? Would it not be a an interaction to `Learn.newVocabulary(<<object>>)` and a `Question` to `Translate.usingPlaceholder(‘SAVE’)`

I started an experiment which already is functional, but I still have problems to use this in some locators, but I think I messed something up with return types, we can discuss this later.

Before I continue I’d like to get you opinion if I’m on the right path and if such a thing would be worth a contribution to Serenity/JS?