### PR TITLE
docs(migration guide): added a migration guide page

### DIFF
--- a/documentation/website/src/handbook-toc.yml
+++ b/documentation/website/src/handbook-toc.yml
@@ -35,6 +35,7 @@ handbook/integration/index.md:
   - handbook/integration/serenityjs-and-protractor.md
   - handbook/integration/jira-and-other-issue-trackers.md
   - handbook/integration/upgrading-to-serenity-js-2.md
+  - handbook/integration/upgrading-to-serenity-js-3.md
 
 handbook/reporting/index.md:
   - handbook/reporting/console-reporter.md

--- a/documentation/website/src/handbook/integration/upgrading-to-serenity-js-3.md
+++ b/documentation/website/src/handbook/integration/upgrading-to-serenity-js-3.md
@@ -1,0 +1,11 @@
+---
+title: Upgrading to Serenity/JS 3.0
+layout: handbook.hbs
+cta: cta-coming-soon
+---
+
+# Upgrading to Serenity/JS 3.0
+
+If you wish to upgrade your existing Serenity/JS 2.x project to use version 3.0 of the framework - this guide is for you!
+
+Until this guide is available, please have a look at https://github.com/serenity-js/serenity-js/issues/1100.


### PR DESCRIPTION
added a migration guide page with coming soon footer and link to GitHub migration guide issue, added
the page to the handbook toc

#re 1157

@jan-molak: According to https://github.com/serenity-js/serenity-js/pull/1195 this would be the PR for master.