### PR TITLE
fix(serenity-bdd): correct detection of invocation location for internal code

### DIFF
--- a/packages/core/src/screenplay/Activity.ts
+++ b/packages/core/src/screenplay/Activity.ts
@@ -59,15 +59,16 @@ export abstract class Activity {
         try {
             throw new Error('Location');
         } catch (error) {
-            const frames = this.errorStackParser.parse(error)
-                .filter(frame => ! (
-                    frame?.fileName.startsWith('node:') ||      // node 16 and 18
-                    frame?.fileName.startsWith('internal') ||   // node 14
-                    frame?.fileName.includes('node_modules')
-                ));
+            const frames = this.errorStackParser.parse(error);
+            const userLandFrames = frames.filter(frame => ! (
+                frame?.fileName.startsWith('node:') ||      // node 16 and 18
+                frame?.fileName.startsWith('internal') ||   // node 14
+                frame?.fileName.includes('node_modules')
+            ));
 
-            const index = Math.min(Math.max(1, frameOffset), frames.length - 1)
-            const invocationFrame = frames[index];
+            const index = Math.min(Math.max(1, frameOffset), userLandFrames.length - 1);
+            // use the desired user-land frame, or the last one from the stack trace for internal invocations
+            const invocationFrame = userLandFrames[index] || frames[frames.length - 1];
 
             return new FileSystemLocation(
                 Path.from(invocationFrame.fileName),


### PR DESCRIPTION
Thanks to @viper3400 for reporting the issue!

<a href="https://gitpod.io/#https://github.com/serenity-js/serenity-js/pull/1313"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

