### PR TITLE
fix(jasmine): remove warn jasmine#addSpecFiles

### DIFF
--- a/packages/jasmine/spec/adapter/FakeJasmineRunner.ts
+++ b/packages/jasmine/spec/adapter/FakeJasmineRunner.ts
@@ -14,7 +14,7 @@ export class FakeJasmineRunner {
     loadRequires    = sinon.spy();
 
     addReporter     = sinon.spy();
-    addSpecFiles    = sinon.spy();
+    addMatchingSpecFiles    = sinon.spy();
     execute         = sinon.spy();
 
     configureDefaultReporter = sinon.spy();

--- a/packages/jasmine/src/adapter/JasmineAdapter.ts
+++ b/packages/jasmine/src/adapter/JasmineAdapter.ts
@@ -104,7 +104,7 @@ export class JasmineAdapter implements TestRunnerAdapter {
     private async loadSpecs(pathsToScenarios: string[]): Promise<void> {
         this.runner.specDir     = '';
         this.runner.specFiles   = [];
-        this.runner.addSpecFiles(pathsToScenarios);
+        this.runner.addMatchingSpecFiles(pathsToScenarios);
 
         await this.runner.loadSpecs();
     }


### PR DESCRIPTION
When using Serenity/JS v3.0.0-rc.32 with Jasmine, some annoying warnings are shown:
```
[wdio-chrome-hubtype] [0-0] DEPRECATION: jasmine#addSpecFiles is deprecated. Use jasmine#addMatchingSpecFiles instead.
[wdio-chrome-hubtype] [0-0]     at <Jasmine>
[wdio-chrome-hubtype] [0-0]     at Jasmine.addSpecFiles (/home/lolo/code/hubtype-qa/acceptance/node_modules/jasmine/lib/jasmine.js:396:12)
[wdio-chrome-hubtype] [0-0]     at JasmineAdapter.loadSpecs (/home/lolo/code/hubtype-qa/acceptance/node_modules/@serenity-js/jasmine/src/adapter/JasmineAdapter.ts:107:21)
[wdio-chrome-hubtype] [0-0]     at JasmineAdapter.load (/home/lolo/code/hubtype-qa/acceptance/node_modules/@serenity-js/jasmine/src/adapter/JasmineAdapter.ts:90:20)
[wdio-chrome-hubtype] [0-0]     at WebdriverIOFrameworkAdapter.init (/home/lolo/code/hubtype-qa/acceptance/node_modules/@serenity-js/webdriverio/src/adapter/WebdriverIOFrameworkAdapter.ts:82:28)
[wdio-chrome-hubtype] [0-0]     at WebdriverIOFrameworkAdapterFactory.init (/home/lolo/code/hubtype-qa/acceptance/node_modules/@serenity-js/webdriverio/src/adapter/WebdriverIOFrameworkAdapterFactory.ts:37:11)
[wdio-chrome-hubtype] [0-0] Note: This message will be shown only once. Set the verboseDeprecations config property to true to see every occurrence.
```
Using `addMatchingSpecFiles` method should fix the issue


<a href="https://gitpod.io/#https://github.com/serenity-js/serenity-js/pull/1347"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

