### PR TITLE
fix(core):  allow proxying location and description fields by `QuestionAdapter`

### DIFF
--- a/packages/core/spec/screenplay/QuestionAdapter.spec.ts
+++ b/packages/core/spec/screenplay/QuestionAdapter.spec.ts
@@ -425,6 +425,8 @@ describe('Question', () => {
                         name: string;
                         caller: string;
                         arguments: boolean;
+                        description: string;
+                        location: string;
                     }
 
                     const Response = () =>
@@ -433,8 +435,8 @@ describe('Question', () => {
                                 // "caller" and "argument" are here to show how a proxy resolves conflicts
                                 // between a built-in fields like function.caller and function.arguments
                                 // and properties of the wrapped object of the same name
-                                { name: 'Alice',    caller: 'Bob',      arguments: false },
-                                { name: 'Bob',      caller: 'Alice',    arguments: true  },
+                                { name: 'Alice',    caller: 'Bob',      arguments: false,   location: 'London',     description: 'first actor' },
+                                { name: 'Bob',      caller: 'Alice',    arguments: true,    location: 'New York',   description: 'second actor'  },
                             ]
                         }));
 
@@ -468,6 +470,22 @@ describe('Question', () => {
                         const result: string = await actor.answer(name);
 
                         expect(result).to.equal('Alice');
+                    });
+
+                    it('proxies "description"', async () => {
+                        const description: Question<Promise<string>> = Response().users[0].description;
+
+                        const result: string = await actor.answer(description);
+
+                        expect(result).to.equal('first actor');
+                    });
+
+                    it('proxies "location"', async () => {
+                        const location: Question<Promise<string>> = Response().users[0].location;
+
+                        const result: string = await actor.answer(location);
+
+                        expect(result).to.equal('London');
                     });
                 });
             });

--- a/packages/core/src/screenplay/Activity.ts
+++ b/packages/core/src/screenplay/Activity.ts
@@ -18,18 +18,22 @@ import { AnswersQuestions, PerformsActivities, UsesAbilities } from './actor';
 export abstract class Activity {
 
     private static errorStackParser = new ErrorStackParser();
+    readonly #description: string;
+    readonly #location: FileSystemLocation;
 
     constructor(
-        protected readonly description: string,
-        private readonly location: FileSystemLocation = Activity.callerLocation(5)
+        description: string,
+        location: FileSystemLocation = Activity.callerLocation(5)
     ) {
+        this.#description = description;
+        this.#location = location;
     }
 
     /**
      * Returns the location where this {@apilink Activity} was instantiated.
      */
     instantiationLocation(): FileSystemLocation {
-        return this.location;
+        return this.#location;
     }
 
     /**
@@ -54,7 +58,7 @@ export abstract class Activity {
      * For example, `#actor clicks on a button` becomes `Wendy clicks on a button`.
      */
     toString(): string {
-        return this.description;
+        return this.#description;
     }
 
     protected static callerLocation(frameOffset: number): FileSystemLocation {

--- a/packages/core/src/screenplay/Question.ts
+++ b/packages/core/src/screenplay/Question.ts
@@ -238,6 +238,7 @@ export abstract class Question<T> {
                         && key === 'describedAs';   // `describedAs` returns `this`, which must be bound to proxy itself to allow proxy chaining
 
                     if (mustAllowProxyChaining) {
+                        // see https://javascript.info/proxy#proxy-limitations
                         return field.bind(receiver)
                     }
 

--- a/packages/core/src/screenplay/Question.ts
+++ b/packages/core/src/screenplay/Question.ts
@@ -229,7 +229,21 @@ export abstract class Question<T> {
                 }
 
                 if (key in target) {
-                    return Reflect.get(target, key);
+
+                    const field = Reflect.get(target, key);
+
+                    const isFunction = typeof field == 'function'
+                    const mustAllowProxyChaining = isFunction
+                        && target instanceof QuestionStatement
+                        && key === 'describedAs';   // `describedAs` returns `this`, which must be bound to proxy itself to allow proxy chaining
+
+                    if (mustAllowProxyChaining) {
+                        return field.bind(receiver)
+                    }
+
+                    return isFunction
+                        ? field.bind(target)
+                        : field;
                 }
 
                 if (key === 'then') {

--- a/packages/web/src/screenplay/interactions/ExecuteScript.ts
+++ b/packages/web/src/screenplay/interactions/ExecuteScript.ts
@@ -248,7 +248,7 @@ class ExecuteAsynchronousScript extends ExecuteScriptWithArguments {
         return new ExecuteAsynchronousScript(
             args.length > 0
                 ? d `#actor executes an asynchronous script with arguments: ${ args }`
-                : this.description,
+                : this.toString(),
             this.script,
             args,
         );
@@ -320,7 +320,7 @@ class ExecuteSynchronousScript extends ExecuteScriptWithArguments {
         return new ExecuteSynchronousScript(
             args.length > 0
                 ? d `#actor executes a synchronous script with arguments: ${ args }`
-                : this.description,
+                : this.toString(),
             this.script,
             args,
         );


### PR DESCRIPTION
Closes #1344

<a href="https://gitpod.io/#https://github.com/serenity-js/serenity-js/pull/1350"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

