### PR TITLE
Missing pharenteses in serenity-js v3 upgrade documentation

### DIFF
--- a/documentation/serenity-js.org/blog/2022-08-12-upgrading-to-serenity-js-3.md
+++ b/documentation/serenity-js.org/blog/2022-08-12-upgrading-to-serenity-js-3.md
@@ -293,7 +293,7 @@ actorCalled('Leonard')
     TakeNotes.using(Notepad.empty<MyNotes>())
   )
   .attemptsTo(
-    notes<MyNotes>.set('credentials', { 
+    notes<MyNotes>().set('credentials', { 
         username: 'leonard@example.org',
         password: 'SuperSecretP@ssword1',
     }),


### PR DESCRIPTION
Missing pharenteses in `notes<MyNotes>().set()` example.