### PR TITLE
test(core): simplified test so that it's stable on GitHub Windows runners

### DIFF
--- a/packages/assertions/spec/EnsureEventually.spec.ts
+++ b/packages/assertions/spec/EnsureEventually.spec.ts
@@ -172,14 +172,14 @@ describe('EnsureEventually', () => {
             const currentCounter = () =>
                 Question.about('value', actor => {
                     counter++
-                    if (counter < 3) {
+                    if (counter < 2) {
                         throw error;
                     }
                     return counter;
                 });
 
             return expect(actorCalled('Enrique').attemptsTo(
-                Ensure.eventually(currentCounter(), isIdenticalTo(3)),
+                Ensure.eventually(currentCounter(), isIdenticalTo(2)),
             )).to.be.fulfilled;
         });
     });


### PR DESCRIPTION
GitHub Windows runners are much slower than the Linux ones, so that the test would time out every now and then. This change should address that.