### PR TITLE
test(web): changed description in Page spec

### DIFF
--- a/integration/web-specs/spec/screenplay/models/Page.spec.ts
+++ b/integration/web-specs/spec/screenplay/models/Page.spec.ts
@@ -46,7 +46,7 @@ describe('Page', () => {
             describe('title()', () => {
 
                 /** @test {Page#title()} */
-                it('returns the value of the <title /> tag of the current page', async () => {
+                it('returns the value of the HTML title tag of the current page', async () => {
                     const page  = await Page.current().answeredBy(actorCalled('Bernie'));
                     const title = await page.title();
 


### PR DESCRIPTION
SerenityBDD report was not able to show descriptions that contain HTML tags like \<title/\>