### PR TITLE
fix(playwright-test): preserve Playwright Test-specific reporting when overriding actors

### DIFF
--- a/packages/playwright-test/src/api/test-api.ts
+++ b/packages/playwright-test/src/api/test-api.ts
@@ -76,7 +76,6 @@ export const it: SerenityTestType = base.extend<Omit<SerenityOptions, 'actors'> 
         async ({ browser, contextOptions, serenity }, use) => {
 
             await use(Cast.where(actor => actor.whoCan(
-                new PerformActivitiesAsPlaywrightSteps(actor, serenity, it),
                 BrowseTheWebWithPlaywright.using(browser, contextOptions),
                 TakeNotes.usingAnEmptyNotepad(),
             )))
@@ -166,7 +165,10 @@ export const it: SerenityTestType = base.extend<Omit<SerenityOptions, 'actors'> 
 
         serenity.engage(asCast(actors));
 
-        const actorCalled = serenity.theActorCalled.bind(serenity);
+        const actorCalled = (name: string) => {
+            const actor = serenity.theActorCalled(name);
+            return actor.whoCan(new PerformActivitiesAsPlaywrightSteps(actor, serenity, it));
+        } ;
 
         serenity.announce(new SceneTagged(
             sceneId,


### PR DESCRIPTION
Since the ability to PerformActivitiesAsPlaywrightSteps was instantiated in the `actors` fixture, overriding this fixture could have affected the Playwright HTML reporter. This change ensures that the ability is correctly attached even if a custom cast is used.