### PR TITLE
feat(core): actors can tell the current time

### DIFF
--- a/packages/core/spec/screenplay/Actor.spec.ts
+++ b/packages/core/spec/screenplay/Actor.spec.ts
@@ -251,6 +251,10 @@ describe('Actor', () => {
             Bob = new Actor('Bob', stage as unknown as Stage);
         });
 
+        it('tells the time', () => {
+            expect(Bob.currentTime()).to.equal(now);
+        })
+
         describe('announces events about the activities it performs', () => {
 
             it('notifies when an activity begins and ends', () => Bob.whoCan(PlayAGuitar.suchAs(guitar)).attemptsTo(

--- a/packages/core/src/events/EmitsDomainEvents.ts
+++ b/packages/core/src/events/EmitsDomainEvents.ts
@@ -1,11 +1,10 @@
 import { ActivityDetails, CorrelationId } from '../model';
-import { Timestamp } from '../screenplay';
+import { TellsTime } from '../screenplay';
 import { DomainEvent } from './DomainEvent';
 
-export interface EmitsDomainEvents {
+export interface EmitsDomainEvents extends TellsTime {
     currentSceneId(): CorrelationId;
     assignNewActivityId(details: ActivityDetails): CorrelationId;
     announce(event: DomainEvent): void;
-    currentTime(): Timestamp;
     waitForNextCue(): Promise<void>,
 }

--- a/packages/core/src/screenplay/Actor.ts
+++ b/packages/core/src/screenplay/Actor.ts
@@ -18,6 +18,7 @@ import { Activity } from './Activity';
 import { Answerable } from './Answerable';
 import { CollectsArtifacts } from './artifacts';
 import { AnswersQuestions } from './questions';
+import { TellsTime, Timestamp } from './time';
 
 /**
  * **Actors** represent **people** and **external systems** interacting with the system under test.
@@ -82,7 +83,9 @@ export class Actor implements PerformsActivities,
     UsesAbilities,
     CanHaveAbilities<Actor>,
     AnswersQuestions,
-    CollectsArtifacts {
+    CollectsArtifacts,
+    TellsTime
+{
     private readonly abilities: Map<AbilityType<Ability>, Ability> = new Map<AbilityType<Ability>, Ability>();
 
     constructor(
@@ -181,6 +184,13 @@ export class Actor implements PerformsActivities,
             artifact,
             this.stage.currentTime(),
         ));
+    }
+
+    /**
+     * Returns current time.
+     */
+    currentTime(): Timestamp {
+        return this.stage.currentTime();
     }
 
     /**

--- a/packages/core/src/screenplay/time/TellsTime.ts
+++ b/packages/core/src/screenplay/time/TellsTime.ts
@@ -1,0 +1,19 @@
+import { Timestamp } from './models';
+
+/**
+ * Describes an {@apilink Actor} or a supporting class capable of telling
+ * the current wall clock time.
+ *
+ * ## Learn more
+ * - {@apilink Actor}
+ * - {@apilink Serenity}
+ * - {@apilink Stage}
+ *
+ * @group Time
+ */
+export interface TellsTime {
+    /**
+     * Returns current wall clock time.
+     */
+    currentTime(): Timestamp;
+}

--- a/packages/core/src/screenplay/time/index.ts
+++ b/packages/core/src/screenplay/time/index.ts
@@ -1,3 +1,4 @@
 export * from './abilities';
 export * from './activities';
 export * from './models';
+export * from './TellsTime';

--- a/packages/core/src/stage/StageManager.ts
+++ b/packages/core/src/stage/StageManager.ts
@@ -1,12 +1,12 @@
 import { AsyncOperationAttempted, AsyncOperationCompleted, AsyncOperationFailed, DomainEvent } from '../events';
 import { CorrelationId, Description, Name } from '../model';
-import { Clock, Duration, Timestamp } from '../screenplay';
+import { Clock, Duration, TellsTime, Timestamp } from '../screenplay';
 import { ListensToDomainEvents } from '../stage';
 
 /**
  * @group Stage
  */
-export class StageManager {
+export class StageManager implements TellsTime {
     private readonly subscribers: ListensToDomainEvents[] = [];
     private readonly wip: WIP;
 


### PR DESCRIPTION
It's now possible for your custom Interactions and Questions to retrieve the current wall clock time directly from the actor via `actor.currentTime()`