### PR TITLE
fix(core): support iOS window handles in CorrelationId

### DIFF
--- a/packages/core/spec/model/CorrelationId.spec.ts
+++ b/packages/core/spec/model/CorrelationId.spec.ts
@@ -11,6 +11,12 @@ describe('CorrelationId', () => {
         }).to.not.throw();
     });
 
+    it('can represent a Window handle from iOS on BrowserStack', () => {
+        expect(() => {
+            new CorrelationId('112786.1')
+        }).to.not.throw();
+    });
+
     it('can be serialised to JSON', () => {
 
         const correlationId = CorrelationId.create();
@@ -32,6 +38,6 @@ describe('CorrelationId', () => {
     it('complains when initialised with an invalid value', () => {
         expect(() => {
             new CorrelationId('invalid value with spaces and special characters!');
-        }).to.throw('CorrelationId should either be a Cuid or match pattern /^[\\dA-Za-z-]+$/');
+        }).to.throw('CorrelationId should either be a Cuid or match pattern /^[\\d.A-Za-z-]+$/');
     });
 });

--- a/packages/core/src/model/CorrelationId.ts
+++ b/packages/core/src/model/CorrelationId.ts
@@ -12,7 +12,7 @@ export class CorrelationId extends TinyType {
 
     constructor(public readonly value: string) {
         super();
-        ensure(this.constructor.name, value, or(isACuid(), matches(/^[\dA-Za-z-]+$/)));
+        ensure(this.constructor.name, value, or(isACuid(), matches(/^[\d.A-Za-z-]+$/)));
     }
 }
 


### PR DESCRIPTION
In BrowserStack, iOS window handles contain the `.` character. This causes the `CorrelationId` constructor to throw, since it checks against a regex that does not allow the `.` character.

**From BrowserStack console:**
![image](https://github.com/serenity-js/serenity-js/assets/1464195/2ea59574-da7d-4844-b13b-7f6d5e99e113)

**Serenity + Webdriver + Mocha log:**
```
[0-0] 2023-08-17T16:56:44.226Z INFO webdriver: COMMAND getWindowHandle()
[0-0] 2023-08-17T16:56:44.228Z INFO webdriver: [GET] https://hub-cloud.browserstack.com/wd/hub/session/5f384ebe43cedc180430b80f67325c9829dac1a8/window
[0-0] 2023-08-17T16:56:44.236Z INFO webdriver: RESULT Test: *********
[0-0] 2023-08-17T16:56:44.386Z INFO webdriver: RESULT 3202.1
[0-0] Error in "*********"
Error: CorrelationId should either be a Cuid or match pattern /^[\dA-Za-z-]+$/
    at ensure ([[redacted]]/node_modules/tiny-types/src/ensure.ts:31:15)
    at new CorrelationId ([[redacted]]/node_modules/@serenity-js/core/src/model/CorrelationId.ts:15:15)
    at Function.fromJSON ([[redacted]]/node_modules/@serenity-js/core/src/model/CorrelationId.ts:6:16)
    at WebdriverIOBrowsingSession.currentPage (file://[[redacted]]/node_modules/@serenity-js/webdriverio/src/screenplay/models/WebdriverIOBrowsingSession.ts:102:57)
    at processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async NavigateToUrl.performAs ([[redacted]]/node_modules/@serenity-js/web/src/screenplay/interactions/Navigate.ts:178:22)
    at async PerformActivities.perform ([[redacted]]/node_modules/@serenity-js/core/src/screenplay/abilities/PerformActivities.ts:53:13)
    at async PerformActivities.perform ([[redacted]]/node_modules/@serenity-js/core/src/screenplay/abilities/PerformActivities.ts:53:13)
    at async Context.<anonymous> ([[redacted]]/spec/mobile/enrollment/enrollment.spec.ts:7:5)
```