### PR TITLE
[DRAFT] fix(core): support multiple base64 RFCs in Artifact serialization

### DIFF
--- a/packages/core/spec/model/Artifact.spec.ts
+++ b/packages/core/spec/model/Artifact.spec.ts
@@ -6,7 +6,7 @@ import { expect } from '../expect';
 describe ('Artifact', () => {
     describe('Photo', () => {
 
-        const photo = Photo.fromBase64('iVBORw0KGgoAAAANSUhEUgAAAAEAAAABAQMAAAAl21bKAAAAA1BMVEW01FWbeM52AAAACklEQVR4nGNiAAAABgADNjd8qAAAAABJRU5ErkJggg==');
+        const photo = Photo.fromBase64('iVBORw0KGgoAAA ANSUhEUgAAAAEAAAABAQMAAAAl21bKAAAAA1BMVE\nW01FWbeM52AAAACklEQVR4nGNiAAAABgADNjd8qAA\r\nAAABJRU5ErkJggg==');
 
         it('can be serialised', () => {
             const serialised = photo.toJSON();

--- a/packages/core/src/model/Artifact.ts
+++ b/packages/core/src/model/Artifact.ts
@@ -55,7 +55,8 @@ export abstract class Artifact extends TinyType {
 }
 
 function looksLikeBase64Encoded(): Predicate<string> {
-    const regex = /^[\d+/=A-Za-z]+$/;
+    // const regex = /^[\d+/=A-Za-z]+$/;
+    const regex = /^[\d\s+/=A-Za-z]+$/;
 
     return Predicate.to(`be base64-encoded`, (value: string) => regex.test(value));
 }


### PR DESCRIPTION
BrowserStack is returning some screenshot data in `base64` with the older RFC 2045 style (see the [variants summary table](https://en.wikipedia.org/wiki/Base64#Variants_summary_table)), which includes mandatory newlines every 76 characters. 

More generally, in this style, whitespace (including newline) is ignored/irrelevant:

```shell-session
$ echo "this is my cool string" | base64
dGhpcyBpcyBteSBjb29sIHN0cmluZwo=

$ echo -e "dGhpcyBpc\\nyBteSBjb29sIH   N0cmluZwo=" | base64 -D
this is my cool string
```

@jan-molak I'm not quite sure the best way to suggest to handle this... I see some options:

1) Sanitize the input strings by removing all whitespace
2) Modify the regex in `looksLikeBase64Encoded()` **which is what I started to do in this PR**
3) Something else?

Thoughts?

<a href="https://gitpod.io/#https://github.com/serenity-js/serenity-js/pull/1870"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

