### PR TITLE
docs(website): installation instructions are now more friendly to Windows users

### DIFF
--- a/documentation/serenity-js.org/docs/design/screenplay-pattern.mdx
+++ b/documentation/serenity-js.org/docs/design/screenplay-pattern.mdx
@@ -335,10 +335,7 @@ ticket.
 If we were using Serenity/JS with a spec-style test runner like [Jasmine](/handbook/test-runners/jasmine), [Mocha](/handbook/test-runners/mocha), or [Playwright Test](/handbook/test-runners/playwright-test),
 we could implement such scenario like this:
 
-<Tabs>
-<TabItem value="playwright-test" label="Playwright Test" default>
-
-```typescript
+```typescript tab={"label":"PlaywrightTest"}
 import { describe, it, test } from '@serenity-js/playwright-test'
 
 test.use({ defaultActorName: 'Trevor' })
@@ -356,10 +353,7 @@ describe('Serenity Airlines flight booking', () => {                            
 })
 ```
 
-</TabItem>
-<TabItem value="mocha" label="Mocha">
-
-```typescript
+```typescript tab={"label":"Mocha"}
 import { actorCalled } from '@serenity-js/core'
 import { describe, it } from 'mocha'
 
@@ -376,10 +370,7 @@ describe('Serenity Airlines flight booking', () => {                            
 })
 ```
 
-</TabItem>
-<TabItem value="jasmine" label="Jasmine">
-
-```typescript
+```typescript tab={"label":"Jasmine"}
 import { actorCalled } from '@serenity-js/core'
 
 describe('Serenity Airlines flight booking', () => {                            // system feature
@@ -394,9 +385,6 @@ describe('Serenity Airlines flight booking', () => {                            
   })
 })
 ```
-
-</TabItem>
-</Tabs>
 
 If we were using [Cucumber.js](/handbook/test-runners/cucumber), the name of the feature, the goal of the scenario,
 as well as the high-level steps necessary to achieve the goal would already be captured in our [`.feature`](https://cucumber.io/docs/gherkin/reference/) files:

--- a/documentation/serenity-js.org/docs/getting-started/installation.mdx
+++ b/documentation/serenity-js.org/docs/getting-started/installation.mdx
@@ -88,10 +88,33 @@ Serenity/JS is typically installed as a [dev dependency](https://docs.npmjs.com/
 of a [Node.js project](https://docs.npmjs.com/files/package.json).
 This way it doesn't accidentally get bundled together with your production dependencies.
 
-If you're introducing Serenity/JS to an existing project you can skip this section as its purpose is to help you
+If you're introducing Serenity/JS to an **existing project** you can skip this section as its purpose is to help you
 create `package.json` - a Node.js project descriptor file, which would already be part of your project.
 
-To create a Node.js project from scratch, create a new directory, such as `serenity-js-example`.
+### Using WebdriverIO installation wizard
+
+If you're planning to start a new project using **WebdriverIO**, use the [WebdriverIO installation wizard](https://webdriver.io/docs/gettingstarted/#initiate-a-webdriverio-setup) to generate the initial structure:
+
+```sh npm2yarn
+npm init wdio .
+```
+
+Next, follow the [Serenity/JS "Getting Started" guide for WebdriverIO](/handbook/getting-started/serenity-js-with-webdriverio/).
+
+### Using Playwright Test installation wizard
+
+If you're planning to use **Playwright Test**, use [Playwright Test installation wizard](https://playwright.dev/docs/intro#installing-playwright):
+
+```sh npm2yarn
+npm init playwright@latest
+```
+
+Next, follow the [Serenity/JS "Getting Started" guide for Playwright Test](/handbook/getting-started/serenity-js-with-playwright-test/)
+
+### Using plain Node.js
+
+If your chosen [test runner](/handbook/test-runners/) doesn't offer an installation wizard,
+or when you want to create a Node.js project from scratch, create a new directory, such as `serenity-js-example`.
 Next, initialise a new Node.js project accepting the default configuration suggested by the npm with these terminal commands:
 
 ```shell
@@ -123,12 +146,19 @@ If you're planning to make your acceptance tests interact with a web interface, 
 The way you install web browsers and their associated drivers depends on whether you want to use [Playwright](/handbook/test-runners/playwright-test)
 or a [Selenium Webdriver](https://www.selenium.dev)-based integration library, such as [WebdriverIO](/handbook/test-runners/webdriverio) or [Protractor](/handbook/test-runners/protractor).
 
-### Using Playwright
+### Using Playwright browsers
 
-For test suites using [Playwright](https://playwright.dev/), install `playwright` module, as well as its browsers and operating system-level dependencies
+To use Serenity/JS with [Playwright](https://playwright.dev/) and its default test runner - [Playwright Test](https://playwright.dev/docs/api/class-test),
+use its [dedicated installation wizard](https://playwright.dev/docs/intro#installing-playwright) then [add Serenity/JS as per the getting started guide](/handbook/getting-started/serenity-js-with-playwright-test/):
+
+```sh npm2yarn
+npm init playwright@latest
+```
+
+To use [Playwright](https://playwright.dev/) with another test runner, like [Cucumber.js](/handbook/test-runners/cucumber/), install the `playwright` module, as well as its browsers and operating system-level dependencies
 by running the below commands in your terminal:
 
-```shell title="serenity-js-example/"
+```sh title="serenity-js-example/"
 npm install --save-dev playwright
 npx playwright install --with-deps
 ```
@@ -142,7 +172,7 @@ you'll need to install the appropriate web browsers and their [associated driver
 
 If you already have [Google Chrome](https://www.google.com/chrome/) installed locally,
 you can add its [driver](https://www.npmjs.com/package/chromedriver) to your Node project by running the following command in your terminal:
-```shell title="serenity-js-example/"
+```sh title="serenity-js-example/"
 npm install --save-dev chromedriver
 ```
 
@@ -157,7 +187,7 @@ Serenity/JS is written in [TypeScript](https://www.typescriptlang.org/) and offe
 
 To use TypeScript in your project, install the following dependencies:
 
-```shell title="serenity-js-example/"
+```sh npm2yarn title="serenity-js-example/"
 npm install typescript @types/node ts-node
 ```
 
@@ -204,14 +234,35 @@ by the Serenity/JS Team from other modules created by the Serenity/JS Community.
 Each [Serenity/JS module](/api) provides detailed installation instructions, and you can install them from your computer
 terminal by running command similar to the one below:
 
-```text
+```sh npm2yarn
 npm install --save-dev @serenity-js/core
 ```
 
-You can also install several Serenity/JS modules simultaneously:
+On **macOS** and **Linux** you can save yourself some keystrokes and install several Serenity/JS modules simultaneously
+thanks to the terminal supporting [Bash brace expansion](https://www.gnu.org/software/bash/manual/html_node/Brace-Expansion.html):
 
-```text
+```sh npm2yarn
 npm install --save-dev @serenity-js/{assertions,console-reporter,core,rest,serenity-bdd}
+```
+
+On **Windows**, or when your shell doesn't support Bash brace expansion, you'll need to specify each Serenity/JS module individually:
+
+```js tab={"label":"macOS/Linux"}
+npm install --save-dev \
+    @serenity-js/assertions \
+    @serenity-js/console-reporter \
+    @serenity-js/core \
+    @serenity-js/rest \
+    @serenity-js/serenity-bdd
+```
+
+```ts tab={"label":"Windows"}
+npm install --save-dev ^
+    @serenity-js/assertions ^
+    @serenity-js/console-reporter ^
+    @serenity-js/core ^
+    @serenity-js/rest ^
+    @serenity-js/serenity-bdd
 ```
 
 :::info Stay up to date
@@ -224,8 +275,22 @@ Serenity/JS (and other publicly available Node modules) from your company intern
 - [Using NPM with JFrog Artifactory](https://www.jfrog.com/confluence/display/JFROG/npm+Registry)
 - [Using NPM with Sonatype Nexus](https://help.sonatype.com/repomanager3/nexus-repository-administration/formats/npm-registry/configuring-npm)
 
+## Configuring a test runner
+
+Follow the below instructions to configure your chosen [test runner](/handbook/test-runners/):
+- [Cucumber](/handbook/test-runners/cucumber)
+- [Jasmine](/handbook/test-runners/jasmine)
+- [Mocha](/handbook/test-runners/mocha)
+- [Playwright Test](/handbook/test-runners/playwright-test)
+- [Protractor](/handbook/test-runners/protractor)
+- [WebdriverIO](/handbook/test-runners/webdriverio)
+
+You might also want to consult the [Serenity/JS Examples and Reference Implementations](https://github.com/serenity-js/serenity-js/tree/main/examples) on GitHub.
+
 ## Examples and reference implementations
 
 If you ever get stuck setting up a Serenity/JS project from scratch, make sure to review:
 - [Serenity/JS Project Templates](/handbook/getting-started/project-templates/)
 - [Serenity/JS Examples and Reference Implementations](https://github.com/serenity-js/serenity-js/tree/main/examples)
+
+Also, remember to join the [Serenity/JS Community chat](https://matrix.to/#/#serenity-js:gitter.im) where you can meet fellow Serenity/JS developers who might be able to help you out.

--- a/documentation/serenity-js.org/docs/getting-started/serenity-js-with-playwright-test.mdx
+++ b/documentation/serenity-js.org/docs/getting-started/serenity-js-with-playwright-test.mdx
@@ -33,14 +33,20 @@ Serenity/JS gives you an optional [web abstraction layer](/api/web) on top of th
 Serenity/JS also provides optional integration libraries to help you write [API tests](/api/rest/),
 [manage local servers](/api/local-server/), [perform assertions](/api/assertions/), and more!
 
-## Installing Serenity/JS
+## Creating a Playwright Test project
 
-You can add Serenity/JS to your existing Playwright Test project, or [create a new project](https://playwright.dev/docs/intro) if you don't have it yet.
+You can add Serenity/JS to an existing Playwright Test project, or create a new project using the [Playwright Test installation wizard](https://playwright.dev/docs/intro#installing-playwright):
+
+```sh npm2yarn
+npm init playwright@latest
+```
+
+## Installing Serenity/JS
 
 To install Serenity/JS from NPM, run the following command:
 
 ```sh npm2yarn
-npm install @serenity-js/{core,web,playwright,playwright-test,assertions,console-reporter,serenity-bdd} --save-dev
+npm install --save-dev @serenity-js/core @serenity-js/web @serenity-js/playwright @serenity-js/playwright-test @serenity-js/assertions @serenity-js/console-reporter @serenity-js/serenity-bdd
 ```
 
 Learn more about [Serenity/JS architecture](/handbook/getting-started/architecture/) and Serenity/JS modules:

--- a/documentation/serenity-js.org/docs/getting-started/serenity-js-with-protractor.mdx
+++ b/documentation/serenity-js.org/docs/getting-started/serenity-js-with-protractor.mdx
@@ -61,7 +61,7 @@ For Protractor test suites, Serenity/JS offers:
 To add Serenity/JS to an [existing Protractor project](https://www.protractortest.org/#/), install the following Serenity/JS modules from NPM:
 
 ```sh npm2yarn
-npm install @serenity-js/{core,web,protractor,assertions,console-reporter,serenity-bdd} --save-dev
+npm install --save-dev @serenity-js/core @serenity-js/web @serenity-js/protractor @serenity-js/assertions @serenity-js/console-reporter @serenity-js/serenity-bdd
 ```
 
 Learn more about Serenity/JS modules:
@@ -76,10 +76,7 @@ Learn more about Serenity/JS modules:
 
 To enable integration with Serenity/JS, configure Protractor as follows:
 
-<Tabs>
-<TabItem value="protractor-conf-cucumber" label="Cucumber" default>
-
-```javascript title="protractor.conf.js"
+```javascript title="protractor.conf.js" tab={"label":"Cucumber"}
 exports.config = {
     // Disable Selenium promise manager
     SELENIUM_PROMISE_MANAGER: false,
@@ -127,10 +124,7 @@ exports.config = {
 };
 ```
 
-</TabItem>
-<TabItem value="protractor-conf-mocha" label="Mocha">
-
-```javascript title="protractor.conf.js"
+```javascript title="protractor.conf.js" tab={"label":"Mocha"}
 exports.config = {
     // Disable Selenium promise manager
     SELENIUM_PROMISE_MANAGER: false,
@@ -175,10 +169,7 @@ exports.config = {
 };
 ```
 
-</TabItem>
-<TabItem value="protractor-conf-jasmine" label="Jasmine">
-
-```javascript title="protractor.conf.js"
+```javascript title="protractor.conf.js" tab={"label":"Jasmine"}
 exports.config = {
     // Disable Selenium promise manager
     SELENIUM_PROMISE_MANAGER: false,
@@ -220,9 +211,6 @@ exports.config = {
     },
 };
 ```
-
-</TabItem>
-</Tabs>
 
 Learn more about:
 - [Serenity/JS Cucumber configuration options](/api/cucumber-adapter/interface/CucumberConfig/)

--- a/documentation/serenity-js.org/docs/getting-started/serenity-js-with-webdriverio.mdx
+++ b/documentation/serenity-js.org/docs/getting-started/serenity-js-with-webdriverio.mdx
@@ -35,12 +35,20 @@ For WebdriverIO test suites, Serenity/JS offers:
 
 ![Serenity BDD Report Example](/images/reporting/serenity-bdd-reporter.png)
 
-## Installing Serenity/JS
+## Creating a WebdriverIO project
 
-To add Serenity/JS to an [existing WebdriverIO project](https://webdriver.io/docs/gettingstarted), install the following Serenity/JS modules from NPM:
+You can add Serenity/JS to an existing WebdriverIO project, or create a new project using the [WebdriverIO installation wizard](https://webdriver.io/docs/gettingstarted/#initiate-a-webdriverio-setup):
 
 ```sh npm2yarn
-npm install @serenity-js/{core,web,webdriverio,assertions,console-reporter,serenity-bdd} --save-dev
+npm init wdio .
+```
+
+## Installing Serenity/JS
+
+To add Serenity/JS to a WebdriverIO project, install the following Serenity/JS modules from NPM:
+
+```sh npm2yarn
+npm install --save-dev @serenity-js/core @serenity-js/web @serenity-js/webdriverio @serenity-js/assertions @serenity-js/console-reporter @serenity-js/serenity-bdd
 ```
 
 Learn more about Serenity/JS modules:
@@ -55,10 +63,7 @@ Learn more about Serenity/JS modules:
 
 To enable integration with Serenity/JS, configure WebdriverIO as follows:
 
-<Tabs>
-<TabItem value="wdio-conf-typescript" label="TypeScript" default>
-
-```typescript title="wdio.conf.ts"
+```typescript title="wdio.conf.ts" tab={"label":"TypeScript"}
 import { WebdriverIOConfig } from '@serenity-js/webdriverio';
 
 export const config: WebdriverIOConfig = {
@@ -114,10 +119,7 @@ export const config: WebdriverIOConfig = {
 };
 ```
 
-</TabItem>
-<TabItem value="wdio-conf-javascript" label="JavaScript">
-
-```typescript title="wdio.conf.js"
+```typescript title="wdio.conf.js" tab={"label":"JavaScript"}
 export const config = {
 
     // Tell WebdriverIO to use Serenity/JS framework
@@ -160,9 +162,6 @@ export const config = {
     // Any other WebdriverIO configuration
 };
 ```
-
-</TabItem>
-</Tabs>
 
 Learn more about:
 - [Serenity/JS Cucumber configuration options](/api/cucumber-adapter/interface/CucumberConfig/)

--- a/documentation/serenity-js.org/docs/integration/gitlab-ci.mdx
+++ b/documentation/serenity-js.org/docs/integration/gitlab-ci.mdx
@@ -48,10 +48,7 @@ For example:
 
 Below example shows basic configuration of a [GitLab CI Pipeline](https://docs.gitlab.com/ee/ci/yaml/gitlab_ci_yaml.html) you can place in the `.gitlab-ci.yml` file in the root directory of your GitLab repository:
 
-<Tabs>
-<TabItem value="node" label="Plain Node" default>
-
-```yaml title=".gitlab-ci.yml"
+```yaml title=".gitlab-ci.yml" tab={"label":"Node"}
 stages:
   - test
 
@@ -69,10 +66,7 @@ serenity:
 # other configuration
 ```
 
-</TabItem>
-<TabItem value="playwright" label="Playwright" default>
-
-```yaml title=".gitlab-ci.yml"
+```yaml title=".gitlab-ci.yml" tab={"label":"Playwright"}
 stages:
   - test
 
@@ -90,10 +84,7 @@ serenity:
 # other configuration
 ```
 
-</TabItem>
-<TabItem value="webdriverio-puppeteer" label="WebdriverIO with Puppeteer" default>
-
-```yaml title=".gitlab-ci.yml"
+```yaml title=".gitlab-ci.yml" tab={"label":"WebdriverIO+Puppeteer"}
 stages:
   - test
 
@@ -111,10 +102,7 @@ serenity:
 # other configuration
 ```
 
-</TabItem>
-<TabItem value="webdriverio-selenium-standalone" label="WebdriverIO with Selenium Standalone" default>
-
-```yaml title=".gitlab-ci.yml"
+```yaml title=".gitlab-ci.yml" tab={"label":"WebdriverIO+SeleniumStandalone"}
 stages:
   - test
 
@@ -136,9 +124,6 @@ serenity:
 
 # other configuration
 ```
-
-</TabItem>
-</Tabs>
 
 **How a GitLab CI pipeline works**:
 - When a code change is pushed to your [source control repository](https://docs.gitlab.com/ee/user/project/repository/), GitLab CI runs your code through the [`stages`](https://docs.gitlab.com/ee/ci/yaml/#stages) of a pipeline you've defined in your pipeline configuration file.
@@ -163,10 +148,7 @@ If the Docker image you use doesn't offer a Java Runtime Environment (JRE), you 
 
 To install a JRE before running the tests, add `apt-get update && apt-get install default-jre -y` to your GitLab CI script:
 
-<Tabs>
-<TabItem value="node" label="Plain Node" default>
-
-```yaml title=".gitlab-ci.yml"
+```yaml title=".gitlab-ci.yml" tab={"label":"Node"}
 stages:
   - test
 
@@ -186,10 +168,7 @@ serenity:
 # other configuration
 ```
 
-</TabItem>
-<TabItem value="playwright" label="Playwright" default>
-
-```yaml title=".gitlab-ci.yml"
+```yaml title=".gitlab-ci.yml" tab={"label":"Playwright"}
 stages:
   - test
 
@@ -209,10 +188,7 @@ serenity:
 # other configuration
 ```
 
-</TabItem>
-<TabItem value="webdriverio-puppeteer" label="WebdriverIO with Puppeteer" default>
-
-```yaml title=".gitlab-ci.yml"
+```yaml title=".gitlab-ci.yml" tab={"label":"WebdriverIO+Puppeteer"}
 stages:
   - test
 
@@ -232,10 +208,7 @@ serenity:
 # other configuration
 ```
 
-</TabItem>
-<TabItem value="webdriverio-selenium-standalone" label="WebdriverIO with Selenium Standalone" default>
-
-```yaml title=".gitlab-ci.yml"
+```yaml title=".gitlab-ci.yml" tab={"label":"WebdriverIO+SeleniumStandalone"}
 stages:
   - test
 
@@ -260,9 +233,6 @@ serenity:
 # other configuration
 ```
 
-</TabItem>
-</Tabs>
-
 ### Building a custom Docker image
 
 To avoid installing the Java Runtime Environment every time your GitLab CI pipeline runs, you might prefer to [build a custom Docker image](https://docs.docker.com/build/building/packaging/),
@@ -270,10 +240,7 @@ publish it to your organisation's artifact registry, and use that image instead.
 
 To add a JRE to your base Docker image of choice, use a `Dockerfile` like in the example below:
 
-<Tabs>
-<TabItem value="node" label="Plain Node" default>
-
-```docker title="Dockerfile"
+```docker title="Dockerfile" tab={"label":"Node"}
 FROM node:lts
 
 RUN apt-get update \
@@ -281,10 +248,7 @@ RUN apt-get update \
  && apt-get clean
 ```
 
-</TabItem>
-<TabItem value="playwright" label="Playwright" default>
-
-```docker title="Dockerfile"
+```docker title="Dockerfile" tab={"label":"Playwright"}
 FROM mcr.microsoft.com/playwright:latest
 
 RUN apt-get update \
@@ -292,19 +256,13 @@ RUN apt-get update \
  && apt-get clean
 ```
 
-</TabItem>
-<TabItem value="webdriverio-puppeteer" label="WebdriverIO with Puppeteer" default>
-
-```docker title="Dockerfile"
+```docker title="Dockerfile" tab={"label":"WebdriverIO+Puppeteer"}
 FROM ghcr.io/puppeteer/puppeteer:latest
 
 RUN apt-get update \
  && apt-get install default-jre -y \
  && apt-get clean
 ```
-
-</TabItem>
-</Tabs>
 
 Next, build and publish your Docker image as per the instructions from your artifact registry vendor:
 - [Artifactory: "Docker registry"](https://jfrog.com/help/r/jfrog-artifactory-documentation/docker-registry)

--- a/documentation/serenity-js.org/docs/reporting/serenity-bdd-reporter.mdx
+++ b/documentation/serenity-js.org/docs/reporting/serenity-bdd-reporter.mdx
@@ -51,8 +51,8 @@ details of any activities performed by Serenity/JS [actors](/api/core/class/Acto
 
 To install the [`@serenity-js/serenity-bdd`](/api/serenity-bdd) module, run the following command in your computer terminal:
 
-```
-npm install --save-dev @serenity-js/{core,serenity-bdd}
+```sh npm2yarn
+npm install --save-dev @serenity-js/core @serenity-js/serenity-bdd
 ```
 
 To learn more about the installation process, [follow the API documentation](/api/serenity-bdd).

--- a/documentation/serenity-js.org/docs/test-runners/cucumber.mdx
+++ b/documentation/serenity-js.org/docs/test-runners/cucumber.mdx
@@ -81,12 +81,12 @@ add the following Node modules:
 - [`@cucumber/cucumber`](https://www.npmjs.com/package/@cucumber/cucumber)
 
 To do that, run the following command in your terminal:
-```shell
-npm install --save-dev @serenity-js/{core,cucumber} @cucumber/cucumber
+```sh npm2yarn
+npm install --save-dev @serenity-js/core @serenity-js/cucumber @cucumber/cucumber
 ```
 
 If you'd like to implement your test suite in TypeScript, also run:
-```shell
+```sh npm2yarn
 npm install --save-dev typescript ts-node @types/node
 ```
 
@@ -96,10 +96,7 @@ If you intend to run your Cucumber scenarios using the [Cucumber CLI](https://gi
 the best way to configure Serenity/JS is to invoke the Serenity/JS [`configure`](/api/core/function/configure) function
 in the Cucumber [`BeforeAll` hook](https://github.com/cucumber/cucumber-js/blob/main/docs/support_files/hooks.md#beforeall--afterall):
 
-<Tabs>
-<TabItem value="typescript" label="TypeScript project" default>
-
-```typescript title="features/support/serenity.config.ts"
+```ts title="features/support/serenity.config.ts" tab={"label":"TypeScript"}
 import { BeforeAll } from '@cucumber/cucumber'
 import { configure } from '@serenity-js/core'
 
@@ -117,10 +114,7 @@ BeforeAll(() => {
 })
 ```
 
-</TabItem>
-<TabItem value="javascript" label="JavaScript project">
-
-```javascript title="features/support/serenity.config.js"
+```js title="features/support/serenity.config.js" tab={"label":"JavaScript"}
 const { BeforeAll } = require('@cucumber/cucumber')
 const { configure } = require('@serenity-js/core')
 
@@ -138,9 +132,6 @@ BeforeAll(() => {
 })
 ```
 
-</TabItem>
-</Tabs>
-
 To learn more about installing and configuring Serenity/JS reporting services appropriate for your project,
 follow the [Serenity/JS reporting guide](/handbook/reporting/).
 
@@ -154,10 +145,7 @@ with feature and scenario descriptions, detailed information about Cucumber step
 To make sure Cucumber loads your Serenity/JS configuration file and correctly interprets TypeScript (if you're using it),
 create a [`cucumber.js` profile](https://github.com/cucumber/cucumber-js/blob/main/docs/profiles.md):
 
-<Tabs>
-<TabItem value="typescript" label="TypeScript project" default>
-
-```javascript title="cucumber.js"
+```js title="cucumber.js" tab={"label":"TypeScript"}
 /**
  * This is a Cucumber.js profile
  * @see https://github.com/cucumber/cucumber-js/blob/main/docs/profiles.md
@@ -175,10 +163,7 @@ module.exports = {
 }
 ```
 
-</TabItem>
-<TabItem value="javascript" label="JavaScript project">
-
-```javascript title="cucumber.js"
+```javascript title="cucumber.js" tab={"label":"JavaScript"}
 /**
  * This is a Cucumber.js profile
  * @see https://github.com/cucumber/cucumber-js/blob/main/docs/profiles.md
@@ -194,9 +179,6 @@ module.exports = {
     ].join(' ')
 }
 ```
-
-</TabItem>
-</Tabs>
 
 The above configuration works with the latest version of the `cucumber.Cli` available as part of
 the [`@cucumber/cucumber`](https://www.npmjs.com/package/@cucumber/cucumber) module.

--- a/documentation/serenity-js.org/docs/test-runners/jasmine.mdx
+++ b/documentation/serenity-js.org/docs/test-runners/jasmine.mdx
@@ -80,13 +80,13 @@ add the following Node modules:
 - [`jasmine`](https://www.npmjs.com/package/jasmine)
 
 To do that, run the following command in your terminal:
-```shell
-npm install --save-dev @serenity-js/{core,jasmine} jasmine
+```npm2yarn
+npm install --save-dev @serenity-js/core @serenity-js/jasmine jasmine
 ```
 
 If you'd like to implement your test suite in TypeScript, also run:
-```shell
-npm install --save-dev typescript ts-node @types/{jasmine,node}
+```sh npm2yarn
+npm install --save-dev typescript ts-node @types/jasmine @types/node
 ```
 
 ### Configuring Serenity/JS
@@ -96,10 +96,7 @@ the best way to configure Serenity/JS is to invoke the Serenity/JS [`configure`]
 in a [`beforeAll` hook](https://jasmine.github.io/api/edge/global.html#beforeAll),
 defined in a Jasmine helper file:
 
-<Tabs>
-<TabItem value="typescript" label="TypeScript project" default>
-
-```typescript title="spec/helpers/serenity.config.ts"
+```ts title="spec/helpers/serenity.config.ts" tab
 import 'jasmine'
 
 import { ArtifactArchiver, configure } from '@serenity-js/core'
@@ -119,10 +116,7 @@ beforeAll(async () => {
 })
 ```
 
-</TabItem>
-<TabItem value="javascript" label="JavaScript project">
-
-```javascript title="spec/helpers/serenity.config.js"
+```js title="spec/helpers/serenity.config.js" tab
 const { configure } = require('@serenity-js/core')
 
 beforeAll(async () => {
@@ -137,9 +131,6 @@ beforeAll(async () => {
     })
 })
 ```
-
-</TabItem>
-</Tabs>
 
 To learn more about installing and configuring Serenity/JS reporting services appropriate for your project,
 follow the [Serenity/JS reporting guide](/handbook/reporting/).

--- a/documentation/serenity-js.org/docs/test-runners/mocha.mdx
+++ b/documentation/serenity-js.org/docs/test-runners/mocha.mdx
@@ -79,13 +79,13 @@ add the following Node modules:
 - [`mocha`](https://www.npmjs.com/package/mocha)
 
 To do that, run the following command in your terminal:
-```shell
-npm install --save-dev @serenity-js/{core,mocha} mocha
+```sh npm2yarn
+npm install --save-dev @serenity-js/core @serenity-js/mocha mocha
 ```
 
 If you'd like to implement your test suite in TypeScript, also run:
-```shell
-npm install --save-dev typescript ts-node @types/{mocha,node}
+```sh npm2yarn
+npm install --save-dev typescript ts-node @types/mocha @types/node
 ```
 
 ### Configuring Serenity/JS
@@ -95,10 +95,7 @@ the best way to configure Serenity/JS is to invoke the Serenity/JS [`configure`]
 in a [`beforeAll` hook](https://mochajs.org/#available-root-hooks),
 defined in a Mocha support file [`required` upon test execution](https://mochajs.org/#-require-module-r-module):
 
-<Tabs>
-<TabItem value="typescript" label="TypeScript project" default>
-
-```typescript title="spec/support/serenity.config.ts"
+```ts title="spec/support/serenity.config.ts" tab
 import 'mocha'
 
 import { configure } from '@serenity-js/core'
@@ -116,10 +113,7 @@ beforeAll(async () => {
 })
 ```
 
-</TabItem>
-<TabItem value="javascript" label="JavaScript project">
-
-```javascript title="spec/support/serenity.config.js"
+```js title="spec/support/serenity.config.js" tab
 const { configure } = require('@serenity-js/core')
 
 beforeAll(async () => {
@@ -135,9 +129,6 @@ beforeAll(async () => {
 })
 ```
 
-</TabItem>
-</Tabs>
-
 To learn more about installing and configuring Serenity/JS reporting services appropriate for your project,
 follow the [Serenity/JS reporting guide](/handbook/reporting/).
 
@@ -147,10 +138,7 @@ To make sure Mocha loads your Serenity/JS configuration file and correctly inter
 create one of the supported [Mocha configuration files](https://mochajs.org/#configuring-mocha-nodejs) in your project
 root directory, e.g. `.mocharc.yml`:
 
-<Tabs>
-<TabItem value="typescript" label="TypeScript project" default>
-
-```yaml title=".mocharc.yml"
+```yaml title=".mocharc.yml" tab={"label":"TypeScript"}
 check-leaks: false
 full-trace: true
 reporter: '@serenity-js/mocha'
@@ -162,10 +150,7 @@ timeout: 5000
 v8-stack-trace-limit: 100
 ```
 
-</TabItem>
-<TabItem value="javascript" label="JavaScript project">
-
-```yaml title=".mocharc.yml"
+```yaml title=".mocharc.yml" tab={"label":"JavaScript"}
 check-leaks: false
 full-trace: true
 reporter: '@serenity-js/mocha'
@@ -175,9 +160,6 @@ spec: 'spec/**/*.spec.js'
 timeout: 5000
 v8-stack-trace-limit: 100
 ```
-
-</TabItem>
-</Tabs>
 
 ### Defining Mocha test scenarios
 

--- a/documentation/serenity-js.org/docs/test-runners/playwright-test.mdx
+++ b/documentation/serenity-js.org/docs/test-runners/playwright-test.mdx
@@ -105,8 +105,8 @@ You might also want to install Serenity/JS reporting services, to accompany your
 - [`@serenity-js/serenity-bdd`](/api/serenity-bdd)
 
 To do the above, run the following command in your terminal:
-```shell
-npm install --save-dev @serenity-js/{core,console-reporter,playwright,playwright-test,web,serenity-bdd}
+```sh npm2yarn
+npm install --save-dev @serenity-js/core @serenity-js/console-reporter @serenity-js/playwright @serenity-js/playwright-test @serenity-js/web @serenity-js/serenity-bdd
 ```
 
 ### Configuring Serenity/JS

--- a/documentation/serenity-js.org/docs/test-runners/protractor.mdx
+++ b/documentation/serenity-js.org/docs/test-runners/protractor.mdx
@@ -111,8 +111,8 @@ You might also want to install Serenity/JS reporting services:
 - [`@serenity-js/serenity-bdd`](/api/serenity-bdd)
 
 To do the above, run the following command in your terminal:
-```shell
-npm install --save-dev @serenity-js/{core,console-reporter,protractor,web,serenity-bdd}
+```sh npm2yarn
+npm install --save-dev @serenity-js/core @serenity-js/console-reporter @serenity-js/protractor @serenity-js/web @serenity-js/serenity-bdd
 ```
 
 Protractor offers a test runner that uses Jasmine, Mocha, or Cucumber to run your test scenarios.

--- a/documentation/serenity-js.org/docs/test-runners/webdriverio.mdx
+++ b/documentation/serenity-js.org/docs/test-runners/webdriverio.mdx
@@ -105,8 +105,8 @@ You might also want to install Serenity/JS reporting services:
 - [`@serenity-js/serenity-bdd`](/api/serenity-bdd)
 
 To do the above, run the following command in your terminal:
-```shell
-npm install --save-dev @serenity-js/{core,console-reporter,webdriverio,web,serenity-bdd}
+```sh npm2yarn
+npm install --save-dev @serenity-js/core @serenity-js/console-reporter @serenity-js/webdriverio @serenity-js/web @serenity-js/serenity-bdd
 ```
 
 WebdriverIO offers a [local runner](https://webdriver.io/docs/runner#local-runner) that

--- a/documentation/serenity-js.org/docusaurus.config.js
+++ b/documentation/serenity-js.org/docusaurus.config.js
@@ -14,11 +14,11 @@ const remarkPlugins = [
     [ require('docusaurus-remark-plugin-tab-blocks'), {
         sync: true,
         labels: [
-            ["json", "JSON"],
-            ["jsx", "JSX"],
-            ["tsx", "TSX"],
-            ["js", "JavaScript"],
-            ["ts", "TypeScript"],
+            ['json', 'JSON'],
+            ['jsx', 'JSX'],
+            ['tsx', 'TSX'],
+            ['js', 'JavaScript'],
+            ['ts', 'TypeScript'],
         ],
     } ]
 ];

--- a/documentation/serenity-js.org/docusaurus.config.js
+++ b/documentation/serenity-js.org/docusaurus.config.js
@@ -11,6 +11,16 @@ const redirects = require('./redirects.config');
 const pkg = require('./../../package.json');
 const remarkPlugins = [
     [ require('@docusaurus/remark-plugin-npm2yarn'), { sync: true, converters: [ 'yarn' ] } ],
+    [ require('docusaurus-remark-plugin-tab-blocks'), {
+        sync: true,
+        labels: [
+            ["json", "JSON"],
+            ["jsx", "JSX"],
+            ["tsx", "TSX"],
+            ["js", "JavaScript"],
+            ["ts", "TypeScript"],
+        ],
+    } ]
 ];
 
 /** @type {import('@docusaurus/types').Config} */

--- a/documentation/serenity-js.org/package.json
+++ b/documentation/serenity-js.org/package.json
@@ -26,6 +26,7 @@
     "@mdx-js/react": "^1.6.22",
     "clsx": "^1.2.1",
     "docusaurus-plugin-typedoc-api": "3.0.0",
+    "docusaurus-remark-plugin-tab-blocks": "^1.3.0",
     "prism-react-renderer": "^1.3.5",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -47,6 +47,7 @@
         "devtools": "8.15.10",
         "diff": "^5.1.0",
         "docusaurus-plugin-typedoc-api": "3.0.0",
+        "docusaurus-remark-plugin-tab-blocks": "^1.3.0",
         "error-stack-parser": "2.1.4",
         "filenamify": "^4.3.0",
         "find-java-home": "^2.0.0",
@@ -383,20 +384,20 @@
       }
     },
     "node_modules/@babel/core": {
-      "version": "7.22.15",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.22.15.tgz",
-      "integrity": "sha512-PtZqMmgRrvj8ruoEOIwVA3yoF91O+Hgw9o7DAUTNBA6Mo2jpu31clx9a7Nz/9JznqetTR6zwfC4L3LAjKQXUwA==",
+      "version": "7.22.17",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.22.17.tgz",
+      "integrity": "sha512-2EENLmhpwplDux5PSsZnSbnSkB3tZ6QTksgO25xwEL7pIDcNOMhF5v/s6RzwjMZzZzw9Ofc30gHv5ChCC8pifQ==",
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.22.13",
         "@babel/generator": "^7.22.15",
         "@babel/helper-compilation-targets": "^7.22.15",
-        "@babel/helper-module-transforms": "^7.22.15",
+        "@babel/helper-module-transforms": "^7.22.17",
         "@babel/helpers": "^7.22.15",
-        "@babel/parser": "^7.22.15",
+        "@babel/parser": "^7.22.16",
         "@babel/template": "^7.22.15",
-        "@babel/traverse": "^7.22.15",
-        "@babel/types": "^7.22.15",
+        "@babel/traverse": "^7.22.17",
+        "@babel/types": "^7.22.17",
         "convert-source-map": "^1.7.0",
         "debug": "^4.1.0",
         "gensync": "^1.0.0-beta.2",
@@ -625,9 +626,9 @@
       }
     },
     "node_modules/@babel/helper-module-transforms": {
-      "version": "7.22.15",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.22.15.tgz",
-      "integrity": "sha512-l1UiX4UyHSFsYt17iQ3Se5pQQZZHa22zyIXURmvkmLCD4t/aU+dvNWHatKac/D9Vm9UES7nvIqHs4jZqKviUmQ==",
+      "version": "7.22.17",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.22.17.tgz",
+      "integrity": "sha512-XouDDhQESrLHTpnBtCKExJdyY4gJCdrvH2Pyv8r8kovX2U8G0dRUOT45T9XlbLtuu9CLXP15eusnkprhoPV5iQ==",
       "dependencies": {
         "@babel/helper-environment-visitor": "^7.22.5",
         "@babel/helper-module-imports": "^7.22.15",
@@ -662,13 +663,13 @@
       }
     },
     "node_modules/@babel/helper-remap-async-to-generator": {
-      "version": "7.22.9",
-      "resolved": "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.22.9.tgz",
-      "integrity": "sha512-8WWC4oR4Px+tr+Fp0X3RHDVfINGpF3ad1HIbrc8A77epiR6eMMc6jsgozkzT2uDiOOdoS9cLIQ+XD2XvI2WSmQ==",
+      "version": "7.22.17",
+      "resolved": "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.22.17.tgz",
+      "integrity": "sha512-bxH77R5gjH3Nkde6/LuncQoLaP16THYPscurp1S8z7S9ZgezCyV3G8Hc+TZiCmY8pz4fp8CvKSgtJMW0FkLAxA==",
       "dependencies": {
         "@babel/helper-annotate-as-pure": "^7.22.5",
         "@babel/helper-environment-visitor": "^7.22.5",
-        "@babel/helper-wrap-function": "^7.22.9"
+        "@babel/helper-wrap-function": "^7.22.17"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -751,13 +752,13 @@
       }
     },
     "node_modules/@babel/helper-wrap-function": {
-      "version": "7.22.10",
-      "resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.22.10.tgz",
-      "integrity": "sha512-OnMhjWjuGYtdoO3FmsEFWvBStBAe2QOgwOLsLNDjN+aaiMD8InJk1/O3HSD8lkqTjCgg5YI34Tz15KNNA3p+nQ==",
+      "version": "7.22.17",
+      "resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.22.17.tgz",
+      "integrity": "sha512-nAhoheCMlrqU41tAojw9GpVEKDlTS8r3lzFmF0lP52LwblCPbuFSO7nGIZoIcoU5NIm1ABrna0cJExE4Ay6l2Q==",
       "dependencies": {
         "@babel/helper-function-name": "^7.22.5",
-        "@babel/template": "^7.22.5",
-        "@babel/types": "^7.22.10"
+        "@babel/template": "^7.22.15",
+        "@babel/types": "^7.22.17"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -2236,9 +2237,9 @@
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.22.15",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.22.15.tgz",
-      "integrity": "sha512-DdHPwvJY0sEeN4xJU5uRLmZjgMMDIvMPniLuYzUVXj/GGzysPl0/fwt44JBkyUIzGJPV8QgHMcQdQ34XFuKTYQ==",
+      "version": "7.22.17",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.22.17.tgz",
+      "integrity": "sha512-xK4Uwm0JnAMvxYZxOVecss85WxTEIbTa7bnGyf/+EgCL5Zt3U7htUpEOWv9detPlamGKuRzCqw74xVglDWpPdg==",
       "dependencies": {
         "@babel/code-frame": "^7.22.13",
         "@babel/generator": "^7.22.15",
@@ -2246,8 +2247,8 @@
         "@babel/helper-function-name": "^7.22.5",
         "@babel/helper-hoist-variables": "^7.22.5",
         "@babel/helper-split-export-declaration": "^7.22.6",
-        "@babel/parser": "^7.22.15",
-        "@babel/types": "^7.22.15",
+        "@babel/parser": "^7.22.16",
+        "@babel/types": "^7.22.17",
         "debug": "^4.1.0",
         "globals": "^11.1.0"
       },
@@ -2264,9 +2265,9 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.22.15",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.22.15.tgz",
-      "integrity": "sha512-X+NLXr0N8XXmN5ZsaQdm9U2SSC3UbIYq/doL++sueHOTisgZHoKaQtZxGuV2cUPQHMfjKEfg/g6oy7Hm6SKFtA==",
+      "version": "7.22.17",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.22.17.tgz",
+      "integrity": "sha512-YSQPHLFtQNE5xN9tHuZnzu8vPr61wVTBZdfv1meex1NBosa4iT05k/Jw06ddJugi4bk7The/oSwQGFcksmEJQg==",
       "dependencies": {
         "@babel/helper-string-parser": "^7.22.5",
         "@babel/helper-validator-identifier": "^7.22.15",
@@ -8272,9 +8273,9 @@
       }
     },
     "node_modules/@wdio/repl/node_modules/@types/node": {
-      "version": "20.5.9",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.5.9.tgz",
-      "integrity": "sha512-PcGNd//40kHAS3sTlzKB9C9XL4K0sTup8nbG5lC14kzEteTNuAFh9u5nA0o5TWnSG2r/JNPRXFVcHJIIeRlmqQ==",
+      "version": "20.6.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.6.0.tgz",
+      "integrity": "sha512-najjVq5KN2vsH2U/xyh2opaSEz6cZMR2SetLIlxlj08nOcmPOemJmUK2o4kUzfLqfrWE0PIrNeE16XhYDd3nqg==",
       "peer": true
     },
     "node_modules/@wdio/types": {
@@ -8289,9 +8290,9 @@
       }
     },
     "node_modules/@wdio/types/node_modules/@types/node": {
-      "version": "20.5.9",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.5.9.tgz",
-      "integrity": "sha512-PcGNd//40kHAS3sTlzKB9C9XL4K0sTup8nbG5lC14kzEteTNuAFh9u5nA0o5TWnSG2r/JNPRXFVcHJIIeRlmqQ=="
+      "version": "20.6.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.6.0.tgz",
+      "integrity": "sha512-najjVq5KN2vsH2U/xyh2opaSEz6cZMR2SetLIlxlj08nOcmPOemJmUK2o4kUzfLqfrWE0PIrNeE16XhYDd3nqg=="
     },
     "node_modules/@wdio/utils": {
       "version": "8.15.10",
@@ -10156,9 +10157,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001528",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001528.tgz",
-      "integrity": "sha512-0Db4yyjR9QMNlsxh+kKWzQtkyflkG/snYheSzkjmvdEtEXB1+jt7A2HmSEiO6XIJPIbo92lHNGNySvE5pZcs5Q==",
+      "version": "1.0.30001532",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001532.tgz",
+      "integrity": "sha512-FbDFnNat3nMnrROzqrsg314zhqN5LGQ1kyyMk2opcrwGbVGpHRhgCWtAgD5YJUqNAiQ+dklreil/c3Qf1dfCTw==",
       "funding": [
         {
           "type": "opencollective",
@@ -13099,9 +13100,9 @@
       }
     },
     "node_modules/devtools/node_modules/@types/node": {
-      "version": "20.5.9",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.5.9.tgz",
-      "integrity": "sha512-PcGNd//40kHAS3sTlzKB9C9XL4K0sTup8nbG5lC14kzEteTNuAFh9u5nA0o5TWnSG2r/JNPRXFVcHJIIeRlmqQ=="
+      "version": "20.6.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.6.0.tgz",
+      "integrity": "sha512-najjVq5KN2vsH2U/xyh2opaSEz6cZMR2SetLIlxlj08nOcmPOemJmUK2o4kUzfLqfrWE0PIrNeE16XhYDd3nqg=="
     },
     "node_modules/devtools/node_modules/chownr": {
       "version": "1.1.4",
@@ -13345,6 +13346,18 @@
       },
       "peerDependencies": {
         "typescript": "4.6.x || 4.7.x || 4.8.x || 4.9.x || 5.0.x"
+      }
+    },
+    "node_modules/docusaurus-remark-plugin-tab-blocks": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/docusaurus-remark-plugin-tab-blocks/-/docusaurus-remark-plugin-tab-blocks-1.3.0.tgz",
+      "integrity": "sha512-qVPKuuVD0JiPbOsPiVUzcGl72nFC6kSPCe+Ywn+e4drAnexmbDyIzWvNZsncm6Lp7BNuU1vetr+al5HgwvUjgA==",
+      "dependencies": {
+        "unist-util-is": "^4.0.0",
+        "unist-util-visit": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/dom-converter": {
@@ -13636,9 +13649,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.511",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.511.tgz",
-      "integrity": "sha512-udHyLfdy390CObLy3uFQitCBvK+WxWu6WZWQMBzO/npNiRy6tanDKR1c/F6OImfAiSt1ylgNszPJBxix2c0w3w=="
+      "version": "1.4.513",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.513.tgz",
+      "integrity": "sha512-cOB0xcInjm+E5qIssHeXJ29BaUyWpMyFKT5RB3bsLENDheCja0wMkHJyiPl0NBE/VzDI7JDuNEQWhe6RitEUcw=="
     },
     "node_modules/elkjs": {
       "version": "0.8.2",
@@ -18246,14 +18259,15 @@
       "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ=="
     },
     "node_modules/json-joy": {
-      "version": "9.5.1",
-      "resolved": "https://registry.npmjs.org/json-joy/-/json-joy-9.5.1.tgz",
-      "integrity": "sha512-XMSpdxaiWUZlc+CAUbPS3G2MZbGxm6clFatqjta/DLrq5V4Y5JU4cx7Qvy7l+XTVPvmRWaYuzzAuCf9uUc40IA==",
+      "version": "9.6.0",
+      "resolved": "https://registry.npmjs.org/json-joy/-/json-joy-9.6.0.tgz",
+      "integrity": "sha512-vJtJD89T0OOZFMaENe95xKCOdibMev/lELkclTdhZxLplwbBPxneWNuctUPizk2nLqtGfBxwCXVO42G9LBoFBA==",
       "dependencies": {
         "arg": "^5.0.2",
         "hyperdyperid": "^1.2.0"
       },
       "bin": {
+        "jj": "bin/jj.js",
         "json-pack": "bin/json-pack.js",
         "json-pack-test": "bin/json-pack-test.js",
         "json-patch": "bin/json-patch.js",
@@ -22846,14 +22860,14 @@
       }
     },
     "node_modules/pino": {
-      "version": "8.15.0",
-      "resolved": "https://registry.npmjs.org/pino/-/pino-8.15.0.tgz",
-      "integrity": "sha512-olUADJByk4twxccmAxb1RiGKOSvddHugCV3wkqjyv+3Sooa2KLrmXrKEWOKi0XPCLasRR5jBXxioE1jxUa4KzQ==",
+      "version": "8.15.1",
+      "resolved": "https://registry.npmjs.org/pino/-/pino-8.15.1.tgz",
+      "integrity": "sha512-Cp4QzUQrvWCRJaQ8Lzv0mJzXVk4z2jlq8JNKMGaixC2Pz5L4l2p95TkuRvYbrEbe85NQsDKrAd4zalf7Ml6WiA==",
       "dependencies": {
         "atomic-sleep": "^1.0.0",
         "fast-redact": "^3.1.1",
         "on-exit-leak-free": "^2.1.0",
-        "pino-abstract-transport": "v1.0.0",
+        "pino-abstract-transport": "v1.1.0",
         "pino-std-serializers": "^6.0.0",
         "process-warning": "^2.0.0",
         "quick-format-unescaped": "^4.0.3",
@@ -22867,9 +22881,9 @@
       }
     },
     "node_modules/pino-abstract-transport": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-1.0.0.tgz",
-      "integrity": "sha512-c7vo5OpW4wIS42hUVcT5REsL8ZljsUfBjqV/e2sFxmFEFZiq1XLUp5EYLtuDH6PEHq9W1egWqRbnLUP5FuZmOA==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-1.1.0.tgz",
+      "integrity": "sha512-lsleG3/2a/JIWUtf9Q5gUNErBqwIu1tUKTT3dUzaf5DySw9ra1wcqKjJjLX1VTY64Wk1eEOYsVGSaGfCK85ekA==",
       "dependencies": {
         "readable-stream": "^4.0.0",
         "split2": "^4.0.0"
@@ -25819,9 +25833,9 @@
       "integrity": "sha512-IXgzBWvWQwE6PrDI05OvmXUIruQTcoMDzRsOd5CDvHCVLcLHMTSYvOK5Cm46kWqlV3yAbuSpBZdJ5oP5OUoStg=="
     },
     "node_modules/rollup": {
-      "version": "3.29.0",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.29.0.tgz",
-      "integrity": "sha512-nszM8DINnx1vSS+TpbWKMkxem0CDWk3cSit/WWCBVs9/JZ1I/XLwOsiUglYuYReaeWWSsW9kge5zE5NZtf/a4w==",
+      "version": "3.29.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.29.1.tgz",
+      "integrity": "sha512-c+ebvQz0VIH4KhhCpDsI+Bik0eT8ZFEVZEYw0cGMVqIP8zc+gnwl7iXCamTw7vzv2MeuZFZfdx5JJIq+ehzDlg==",
       "bin": {
         "rollup": "dist/bin/rollup"
       },
@@ -28609,9 +28623,9 @@
       }
     },
     "node_modules/ua-parser-js": {
-      "version": "1.0.35",
-      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-1.0.35.tgz",
-      "integrity": "sha512-fKnGuqmTBnIE+/KXSzCn4db8RTigUzw1AN0DmdU6hJovUTbYJKyqj+8Mt1c4VfRDnOVJnENmfYkIPZ946UrSAA==",
+      "version": "1.0.36",
+      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-1.0.36.tgz",
+      "integrity": "sha512-znuyCIXzl8ciS3+y3fHJI/2OhQIXbXw9MWC/o3qwyR+RGppjZHrM27CGFSKCJXi2Kctiz537iOu2KnXs1lMQhw==",
       "funding": [
         {
           "type": "opencollective",
@@ -28620,6 +28634,10 @@
         {
           "type": "paypal",
           "url": "https://paypal.me/faisalman"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/faisalman"
         }
       ],
       "engines": {
@@ -29595,9 +29613,9 @@
       }
     },
     "node_modules/webdriver/node_modules/@types/node": {
-      "version": "20.5.9",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.5.9.tgz",
-      "integrity": "sha512-PcGNd//40kHAS3sTlzKB9C9XL4K0sTup8nbG5lC14kzEteTNuAFh9u5nA0o5TWnSG2r/JNPRXFVcHJIIeRlmqQ==",
+      "version": "20.6.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.6.0.tgz",
+      "integrity": "sha512-najjVq5KN2vsH2U/xyh2opaSEz6cZMR2SetLIlxlj08nOcmPOemJmUK2o4kUzfLqfrWE0PIrNeE16XhYDd3nqg==",
       "peer": true
     },
     "node_modules/webdriver/node_modules/@wdio/config": {
@@ -30024,9 +30042,9 @@
       }
     },
     "node_modules/webdriverio": {
-      "version": "8.16.5",
-      "resolved": "https://registry.npmjs.org/webdriverio/-/webdriverio-8.16.5.tgz",
-      "integrity": "sha512-dkG3cha1LAnyEVDR3Cpp8++gmxM/VjFHyQRoM+E0aGkY//B6z3nmmNtXBRr9d7XFI49WZf6ctnQ/B0ORoCnYKg==",
+      "version": "8.16.6",
+      "resolved": "https://registry.npmjs.org/webdriverio/-/webdriverio-8.16.6.tgz",
+      "integrity": "sha512-DVP/2QlaFxpt6nFgtze4k3uV6rU/LpwszcPSAvzNnUjhDwnIsDj9+/WZqe0iEzkx0JdKNaWZEuDSZmZYXk3EtA==",
       "peer": true,
       "dependencies": {
         "@types/node": "^20.1.0",
@@ -30067,9 +30085,9 @@
       }
     },
     "node_modules/webdriverio/node_modules/@types/node": {
-      "version": "20.5.9",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.5.9.tgz",
-      "integrity": "sha512-PcGNd//40kHAS3sTlzKB9C9XL4K0sTup8nbG5lC14kzEteTNuAFh9u5nA0o5TWnSG2r/JNPRXFVcHJIIeRlmqQ==",
+      "version": "20.6.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.6.0.tgz",
+      "integrity": "sha512-najjVq5KN2vsH2U/xyh2opaSEz6cZMR2SetLIlxlj08nOcmPOemJmUK2o4kUzfLqfrWE0PIrNeE16XhYDd3nqg==",
       "peer": true
     },
     "node_modules/webdriverio/node_modules/@wdio/config": {

--- a/packages/assertions/README.md
+++ b/packages/assertions/README.md
@@ -9,9 +9,10 @@
 of complex software systems faster, more collaborative and easier to scale.
 
 ⭐️ Get started with Serenity/JS!
-- [Serenity/JS Handbook](https://serenity-js.org/handbook) and [tutorial](https://serenity-js.org/handbook/web-testing/your-first-web-scenario),
-- [API documentation](https://serenity-js.org/api/core),
-- [Serenity/JS project templates on GitHub](https://serenity-js.org/handbook/getting-started#serenityjs-project-templates).
+- [Serenity/JS web testing tutorial](https://serenity-js.org/handbook/web-testing/your-first-web-scenario)
+- [Serenity/JS Handbook](https://serenity-js.org/handbook) and [Getting Started guides](https://serenity-js.org/handbook/getting-started/)
+- [API documentation](https://serenity-js.org/api/core)
+- [Serenity/JS Project Templates on GitHub](https://serenity-js.org/handbook/getting-started#serenityjs-project-templates)
 
 👋 Join the Serenity/JS Community!
 - Meet other Serenity/JS developers and maintainers on the [Serenity/JS Community chat channel](https://matrix.to/#/#serenity-js:gitter.im),
@@ -26,16 +27,19 @@ of complex software systems faster, more collaborative and easier to scale.
 ### Installation
 
 To install this module, run the following command in your computer terminal:
-```console
-npm install --save-dev @serenity-js/{core,assertions}
+
+```sh
+npm install --save-dev @serenity-js/core @serenity-js/assertions
 ```
+
+To learn more about Serenity/JS and how to use it on your project, follow the [Serenity/JS Getting Started guide](https://serenity-js.org/handbook/getting-started/).
 
 ### Performing verifications using `Ensure`
 
 ```typescript
-import { Ensure, endsWith } from '@serenity-js/assertions';
-import { actorCalled } from '@serenity-js/core';
-import { Navigate, Page } from '@serenity-js/web';
+import { Ensure, endsWith } from '@serenity-js/assertions'
+import { actorCalled } from '@serenity-js/core'
+import { Navigate, Page } from '@serenity-js/web'
 
 await actorCalled('Erica').attemptsTo(
     Navigate.to('https://serenity-js.org'),
@@ -43,55 +47,55 @@ await actorCalled('Erica').attemptsTo(
         Page.current().title(), 
         endsWith('Serenity/JS')
     ),
-);
+)
 ```
 
 ### Controlling execution flow using `Check`
 
 ```typescript
-import { actorCalled } from '@serenity-js/core';
-import { Check } from '@serenity-js/assertions'; 
-import { Click, isVisible } from '@serenity-js/protractor';
+import { actorCalled } from '@serenity-js/core'
+import { Check } from '@serenity-js/assertions' 
+import { Click, isVisible } from '@serenity-js/protractor'
 
 await actorCalled('Erica').attemptsTo(
     Check.whether(NewsletterModal, isVisible())
         .andIfSo(Click.on(CloseModalButton)),
-);
+)
 ```
 
 ### Synchronising the test with the System Under Test using `Wait`
 
 ```typescript
-import { actorCalled } from '@serenity-js/core';
-import { Click, isVisible, Wait } from '@serenity-js/protractor';
+import { actorCalled } from '@serenity-js/core'
+import { Click, isVisible, Wait } from '@serenity-js/protractor'
 
 await actorCalled('Erica').attemptsTo(
     Wait.until(CloseModalButton, isVisible()),
     Click.on(CloseModalButton)
-);
+)
 ```
 
 ### Defining custom expectations using `Expectation.thatActualShould`
 
 ```typescript
-import { actorCalled } from '@serenity-js/core';
-import { Expectation, Ensure } from '@serenity-js/assertions';
+import { actorCalled } from '@serenity-js/core'
+import { Expectation, Ensure } from '@serenity-js/assertions'
 
 function isDivisibleBy(expected: Answerable<number>): Expectation<number> {
     return Expectation.thatActualShould<number, number>('have value divisible by', expected)
-        .soThat((actualValue, expectedValue) => actualValue % expectedValue === 0);
+        .soThat((actualValue, expectedValue) => actualValue % expectedValue === 0)
 }
 
 await actorCalled('Erica').attemptsTo(
     Ensure.that(4, isDivisibleBy(2)),
-);
+)
 ```
 
 ### Composing expectations using `Expectation.to`
 
 ```typescript
-import { actorCalled } from '@serenity-js/core';
-import { Expectation, Ensure, and, or, isGreaterThan, isLessThan, equals  } from '@serenity-js/assertions';
+import { actorCalled } from '@serenity-js/core'
+import { Expectation, Ensure, and, or, isGreaterThan, isLessThan, equals  } from '@serenity-js/assertions'
 
 function isWithin(lowerBound: number, upperBound: number) {
     return Expectation
@@ -99,12 +103,12 @@ function isWithin(lowerBound: number, upperBound: number) {
         .soThatActual(and(
            or(isGreaterThan(lowerBound), equals(lowerBound)),
            or(isLessThan(upperBound), equals(upperBound)),
-        ));
+        ))
 }
 
 await actorCalled('Erica').attemptsTo(
     Ensure.that(5, isWithin(3, 6)),
-);
+)
 ```
 
 ## 📣 Stay up to date

--- a/packages/console-reporter/README.md
+++ b/packages/console-reporter/README.md
@@ -9,9 +9,10 @@
 of complex software systems faster, more collaborative and easier to scale.
 
 ⭐️ Get started with Serenity/JS!
-- [Serenity/JS Handbook](https://serenity-js.org/handbook) and [tutorial](https://serenity-js.org/handbook/web-testing/your-first-web-scenario),
-- [API documentation](https://serenity-js.org/api/core),
-- [Serenity/JS project templates on GitHub](https://serenity-js.org/handbook/getting-started#serenityjs-project-templates).
+- [Serenity/JS web testing tutorial](https://serenity-js.org/handbook/web-testing/your-first-web-scenario)
+- [Serenity/JS Handbook](https://serenity-js.org/handbook) and [Getting Started guides](https://serenity-js.org/handbook/getting-started/)
+- [API documentation](https://serenity-js.org/api/core)
+- [Serenity/JS Project Templates on GitHub](https://serenity-js.org/handbook/getting-started#serenityjs-project-templates)
 
 👋 Join the Serenity/JS Community!
 - Meet other Serenity/JS developers and maintainers on the [Serenity/JS Community chat channel](https://matrix.to/#/#serenity-js:gitter.im),
@@ -27,11 +28,11 @@ to your computer terminal.
 
 ### Installation
 
-```console
-npm install --save-dev @serenity-js/{core,console-reporter}
+```sh
+npm install --save-dev @serenity-js/core @serenity-js/console-reporter
 ```
 
-Learn more about [Serenity/JS Console Reporter](https://serenity-js.org/handbook/reporting/console-reporter.html)
+To learn more about Serenity/JS and how to use it on your project, follow the [Serenity/JS Getting Started guide](https://serenity-js.org/handbook/getting-started/).
 
 #### Windows
 
@@ -54,7 +55,7 @@ Learn more about using [Serenity/JS with Playwright Test](https://serenity-js.or
 
 ```typescript
 // playwright.config.ts
-import type { PlaywrightTestConfig } from '@serenity-js/playwright-test';
+import type { PlaywrightTestConfig } from '@serenity-js/playwright-test'
 
 const config: PlaywrightTestConfig = {
     reporter: [
@@ -71,9 +72,9 @@ const config: PlaywrightTestConfig = {
 
     // Other configuration omitted for brevity
     // For details, see https://playwright.dev/docs/test-configuration    
-};
+}
 
-export default config;
+export default config
 ```
 
 #### Usage with WebdriverIO
@@ -83,7 +84,7 @@ Learn more about using [Serenity/JS with WebdriverIO](https://serenity-js.org/ap
 ```typescript
 // wdio.conf.ts
 
-import { WebdriverIOConfig } from '@serenity-js/webdriverio';
+import { WebdriverIOConfig } from '@serenity-js/webdriverio'
 
 export const config: WebdriverIOConfig = {
 
@@ -101,7 +102,7 @@ export const config: WebdriverIOConfig = {
 
     // Other configuration omitted for brevity
     // For details, see https://webdriver.io/docs/options
-};
+}
 ```
 
 #### Usage with Protractor
@@ -135,14 +136,14 @@ exports.config = {
 Learn more about [configuring Serenity/JS programmatically](https://serenity-js.org/api/core/class/SerenityConfig).
 
 ```typescript
-import { configure } from '@serenity-js/core';
-import { ConsoleReporter } from '@serenity-js/console-reporter';
+import { configure } from '@serenity-js/core'
+import { ConsoleReporter } from '@serenity-js/console-reporter'
 
 configure({
     crew: [
         ConsoleReporter.withDefaultColourSupport(),
     ],
-});
+})
 ```
 
 #### Colour Themes

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -9,9 +9,10 @@
 of complex software systems faster, more collaborative and easier to scale.
 
 ⭐️ Get started with Serenity/JS!
-- [Serenity/JS Handbook](https://serenity-js.org/handbook) and [tutorial](https://serenity-js.org/handbook/web-testing/your-first-web-scenario),
-- [API documentation](https://serenity-js.org/api/core),
-- [Serenity/JS project templates on GitHub](https://serenity-js.org/handbook/getting-started#serenityjs-project-templates).
+- [Serenity/JS web testing tutorial](https://serenity-js.org/handbook/web-testing/your-first-web-scenario)
+- [Serenity/JS Handbook](https://serenity-js.org/handbook) and [Getting Started guides](https://serenity-js.org/handbook/getting-started/)
+- [API documentation](https://serenity-js.org/api/core)
+- [Serenity/JS Project Templates on GitHub](https://serenity-js.org/handbook/getting-started#serenityjs-project-templates)
 
 👋 Join the Serenity/JS Community!
 - Meet other Serenity/JS developers and maintainers on the [Serenity/JS Community chat channel](https://matrix.to/#/#serenity-js:gitter.im),
@@ -32,6 +33,8 @@ To install this module, run the following command in your computer terminal:
 ```
 npm install --save-dev @serenity-js/core
 ```
+
+To learn more about Serenity/JS and how to use it on your project, follow the [Serenity/JS Getting Started guide](https://serenity-js.org/handbook/getting-started/).
 
 ## 📣 Stay up to date
 

--- a/packages/cucumber/README.md
+++ b/packages/cucumber/README.md
@@ -9,9 +9,10 @@
 of complex software systems faster, more collaborative and easier to scale.
 
 ⭐️ Get started with Serenity/JS!
-- [Serenity/JS Handbook](https://serenity-js.org/handbook) and [tutorial](https://serenity-js.org/handbook/web-testing/your-first-web-scenario),
-- [API documentation](https://serenity-js.org/api/core),
-- [Serenity/JS project templates on GitHub](https://serenity-js.org/handbook/getting-started#serenityjs-project-templates).
+- [Serenity/JS web testing tutorial](https://serenity-js.org/handbook/web-testing/your-first-web-scenario)
+- [Serenity/JS Handbook](https://serenity-js.org/handbook) and [Getting Started guides](https://serenity-js.org/handbook/getting-started/)
+- [API documentation](https://serenity-js.org/api/core)
+- [Serenity/JS Project Templates on GitHub](https://serenity-js.org/handbook/getting-started#serenityjs-project-templates)
 
 👋 Join the Serenity/JS Community!
 - Meet other Serenity/JS developers and maintainers on the [Serenity/JS Community chat channel](https://matrix.to/#/#serenity-js:gitter.im),
@@ -33,13 +34,13 @@ Learn more about integrating Serenity/JS Cucumber:
 
 To install this module, run:
 ```
-npm install --save-dev @serenity-js/{cucumber,core}
+npm install --save-dev @serenity-js/cucumber @serenity-js/core
 ```
 
-This module reports test scenarios executed by **any version of Cucumber.js**, from 0.x to 7.x, which you need to install
+This module reports test scenarios executed by **any version of Cucumber.js**, from 0.x to 9.x, which you need to install
 separately.
 
-To install [Cucumber 7.x](https://www.npmjs.com/package/@cucumber/cucumber), run:
+To install [Cucumber 9.x](https://www.npmjs.com/package/@cucumber/cucumber), run:
 ```
 npm install --save-dev @cucumber/cucumber 
 ```
@@ -49,9 +50,11 @@ To install [Cucumber 6.x](https://www.npmjs.com/package/cucumber) or earlier, ru
 npm install --save-dev cucumber 
 ```
 
+To learn more about Serenity/JS and how to use it on your project, follow the [Serenity/JS Getting Started guide](https://serenity-js.org/handbook/getting-started/).
+
 ### Command line usage
 
-#### Cucumber 7.x
+#### Cucumber 7.x and newer
 
 ```
 cucumber-js --format @serenity-js/cucumber \
@@ -82,11 +85,11 @@ When used with a configuration file written in JavaScript:
 ```javascript
 // features/support/setup.js
 
-const { configure } = require('@serenity-js/core');
+const { configure } = require('@serenity-js/core')
 
 configure({
     // ... configure Serenity/JS 
-});
+})
 ```
 
 When used with a configuration file written in TypeScript:
@@ -94,11 +97,11 @@ When used with a configuration file written in TypeScript:
 ```typescript
 // features/support/setup.ts
 
-import { configure } from '@serenity-js/core';
+import { configure } from '@serenity-js/core'
 
 configure({
     // ... configure Serenity/JS 
-});
+})
 ```
 
 ### Integration

--- a/packages/jasmine/README.md
+++ b/packages/jasmine/README.md
@@ -9,9 +9,10 @@
 of complex software systems faster, more collaborative and easier to scale.
 
 ⭐️ Get started with Serenity/JS!
-- [Serenity/JS Handbook](https://serenity-js.org/handbook) and [tutorial](https://serenity-js.org/handbook/web-testing/your-first-web-scenario),
-- [API documentation](https://serenity-js.org/api/core),
-- [Serenity/JS project templates on GitHub](https://serenity-js.org/handbook/getting-started#serenityjs-project-templates).
+- [Serenity/JS web testing tutorial](https://serenity-js.org/handbook/web-testing/your-first-web-scenario)
+- [Serenity/JS Handbook](https://serenity-js.org/handbook) and [Getting Started guides](https://serenity-js.org/handbook/getting-started/)
+- [API documentation](https://serenity-js.org/api/core)
+- [Serenity/JS Project Templates on GitHub](https://serenity-js.org/handbook/getting-started#serenityjs-project-templates)
 
 👋 Join the Serenity/JS Community!
 - Meet other Serenity/JS developers and maintainers on the [Serenity/JS Community chat channel](https://matrix.to/#/#serenity-js:gitter.im),
@@ -28,11 +29,12 @@ to enable integration between Jasmine and Serenity/JS.
 ### Installation
 
 To install this module, run the following command in your computer terminal:
-```console
-npm install --save-dev @serenity-js/{core,jasmine}
+
+```sh
+npm install --save-dev @serenity-js/core @serenity-js/jasmine
 ```
 
-Learn more about [integrating Serenity/JS with Jasmine](https://serenity-js.org/handbook/test-runners/jasmine/)
+To learn more about Serenity/JS and how to use it on your project, follow the [Serenity/JS Getting Started guide](https://serenity-js.org/handbook/getting-started/).
 
 ### Command line usage
 
@@ -43,9 +45,9 @@ jasmine --reporter=@serenity-js/jasmine
 ### Programmatic usage
 
 ```typescript
-import serenityReporterForJasmine = require('@serenity-js/jasmine');
+import serenityReporterForJasmine = require('@serenity-js/jasmine')
 
-jasmine.getEnv().addReporter(serenityReporterForJasmine);
+jasmine.getEnv().addReporter(serenityReporterForJasmine)
 ```
 
 ## 📣 Stay up to date

--- a/packages/local-server/README.md
+++ b/packages/local-server/README.md
@@ -9,9 +9,10 @@
 of complex software systems faster, more collaborative and easier to scale.
 
 ⭐️ Get started with Serenity/JS!
-- [Serenity/JS Handbook](https://serenity-js.org/handbook) and [tutorial](https://serenity-js.org/handbook/web-testing/your-first-web-scenario),
-- [API documentation](https://serenity-js.org/api/core),
-- [Serenity/JS project templates on GitHub](https://serenity-js.org/handbook/getting-started#serenityjs-project-templates).
+- [Serenity/JS web testing tutorial](https://serenity-js.org/handbook/web-testing/your-first-web-scenario)
+- [Serenity/JS Handbook](https://serenity-js.org/handbook) and [Getting Started guides](https://serenity-js.org/handbook/getting-started/)
+- [API documentation](https://serenity-js.org/api/core)
+- [Serenity/JS Project Templates on GitHub](https://serenity-js.org/handbook/getting-started#serenityjs-project-templates)
 
 👋 Join the Serenity/JS Community!
 - Meet other Serenity/JS developers and maintainers on the [Serenity/JS Community chat channel](https://matrix.to/#/#serenity-js:gitter.im),
@@ -30,27 +31,30 @@ or raw [Node.js](https://nodejs.org/en/docs/guides/anatomy-of-an-http-transactio
 ### Installation
 
 To install this module, run the following command in your computer terminal:
-```console
-npm install --save-dev @serenity-js/{core,local-server}
+
+```sh
+npm install --save-dev @serenity-js/core @serenity-js/local-server
 ```
+
+To learn more about Serenity/JS and how to use it on your project, follow the [Serenity/JS Getting Started guide](https://serenity-js.org/handbook/getting-started/).
 
 ### Example test
 
 ```typescript
-import { actorCalled } from '@serenity-js/core';
+import { actorCalled } from '@serenity-js/core'
 import {
     ManageALocalServer, StartLocalTestServer, StopLocalTestServer
 } from '@serenity-js/local-server'
-import { CallAnApi, GetRequest, Send } from '@serenity-js/rest';
-import { Ensure, equals } from '@serenity-js/assertions';
-import axios from 'axios';
+import { CallAnApi, GetRequest, Send } from '@serenity-js/rest'
+import { Ensure, equals } from '@serenity-js/assertions'
+import axios from 'axios'
 
-import { requestListener } from './listener';                           (1)
+import { requestListener } from './listener'                            (1)
 
 const actor = actorCalled('Apisit').whoCan(
     ManageALocalServer.using(requestListener),                          (2)
     CallAnApi.using(axios.create()),
-);
+)
 
 await actor.attemptsTo(
     StartLocalTestServer.onRandomPort(),                                (3)
@@ -58,7 +62,7 @@ await actor.attemptsTo(
     Ensure.that(LastResponse.status(), equals(200)),
     Ensure.that(LastResponse.body(), equals('Hello!')),
     StopLocalTestServer.ifRunning(),                                    (5)
-);
+)
 ```
 
 In the above example:
@@ -84,8 +88,8 @@ satisfy the above test.
 ```javascript
 // listener.js
 module.exports.requestListener = (request, response) => {
-  response.setHeader('Connection', 'close');
-  response.end('Hello World!');
+  response.setHeader('Connection', 'close')
+  response.end('Hello World!')
 }
 ```
 
@@ -95,12 +99,12 @@ module.exports.requestListener = (request, response) => {
 
 ```javascript
 // listener.js
-const express = require('express');
+const express = require('express')
 
 module.exports.requestListener = express().
     get('/', (req: express.Request, res: express.Response) => {
-        res.status(200).send('Hello World!');
-    });
+        res.status(200).send('Hello World!')
+    })
 ```
 
 [Learn more about Express](https://expressjs.com/).
@@ -109,12 +113,12 @@ module.exports.requestListener = express().
 
 ```javascript
 // listener.js
-const hapi = require('@hapi/hapi');
+const hapi = require('@hapi/hapi')
 
-const server = new hapi.Server();
+const server = new hapi.Server()
 server.route({ method: 'GET', path: '/', handler: (req, h) => 'Hello World!' })
 
-module.exports.requestListener = server.listener;
+module.exports.requestListener = server.listener
 ```
 
 [Learn more about HAPI](https://hapijs.com/).
@@ -123,11 +127,11 @@ module.exports.requestListener = server.listener;
 
 ```javascript
 // listener.js
-const Koa = require('koa');
+const Koa = require('koa')
 
 module.exports.requestListener = new Koa()
     .use(ctx => Promise.resolve(ctx.body = 'Hello World!'))
-    .callback();
+    .callback()
 ```
 
 [Learn more about Koa](https://koajs.com/).
@@ -136,15 +140,15 @@ module.exports.requestListener = new Koa()
 
 ```javascript
 // listener.js
-const restify = require('restify');
+const restify = require('restify')
 
-const server = restify.createServer(options);
+const server = restify.createServer(options)
 
 server.get('/', (req, res, next) => {
-    res.send('Hello World!');
-});
+    res.send('Hello World!')
+})
 
-module.exports.requestListener = server;
+module.exports.requestListener = server
 ```
 
 [Learn more about Restify](http://restify.com/).

--- a/packages/mocha/README.md
+++ b/packages/mocha/README.md
@@ -9,9 +9,10 @@
 of complex software systems faster, more collaborative and easier to scale.
 
 ⭐️ Get started with Serenity/JS!
-- [Serenity/JS Handbook](https://serenity-js.org/handbook) and [tutorial](https://serenity-js.org/handbook/web-testing/your-first-web-scenario),
-- [API documentation](https://serenity-js.org/api/core),
-- [Serenity/JS project templates on GitHub](https://serenity-js.org/handbook/getting-started#serenityjs-project-templates).
+- [Serenity/JS web testing tutorial](https://serenity-js.org/handbook/web-testing/your-first-web-scenario)
+- [Serenity/JS Handbook](https://serenity-js.org/handbook) and [Getting Started guides](https://serenity-js.org/handbook/getting-started/)
+- [API documentation](https://serenity-js.org/api/core)
+- [Serenity/JS Project Templates on GitHub](https://serenity-js.org/handbook/getting-started#serenityjs-project-templates)
 
 👋 Join the Serenity/JS Community!
 - Meet other Serenity/JS developers and maintainers on the [Serenity/JS Community chat channel](https://matrix.to/#/#serenity-js:gitter.im),
@@ -27,17 +28,17 @@ of complex software systems faster, more collaborative and easier to scale.
 
 Install [Mocha](https://mochajs.org/) version 8.x or newer:
 
-```console
+```sh
 npm install --save-dev mocha@8.x
 ```
 
 Install the `@serenity-js/mocha` adapter, as well as `@serenity-js/core` and any [Serenity/JS reporting modules](https://serenity-js.org/api/console-reporter/) you'd like to use, for example [`@serenity-js/console-reporter`](https://serenity-js.org/api/console-reporter/):
 
-```console
-npm install --save-dev @serenity-js/{core,console-reporter,mocha}
+```sh
+npm install --save-dev @serenity-js/core @serenity-js/console-reporter @serenity-js/mocha
 ```
 
-Learn more about [integrating Serenity/JS with Mocha](https://serenity-js.org/handbook/test-runners/mocha/)
+To learn more about Serenity/JS and how to use it on your project, follow the [Serenity/JS Getting Started guide](https://serenity-js.org/handbook/getting-started/).
 
 ### Usage with standalone Mocha
 
@@ -59,7 +60,7 @@ configure({
     crew: [
         ConsoleReporter.forDarkTerminals(),
     ],
-});
+})
 ```
 
 Next, run Mocha as follows:
@@ -95,14 +96,14 @@ Create a `setup.ts` file (for example under `spec/support/setup.ts`, but you can
 ```typescript
 // spec/support/setup.ts
 
-import { ConsoleReporter } from '@serenity-js/console-reporter';
-import { configure } from '@serenity-js/core';
+import { ConsoleReporter } from '@serenity-js/console-reporter'
+import { configure } from '@serenity-js/core'
 
 configure({
     crew: [
         ConsoleReporter.forDarkTerminals(),
     ],
-});
+})
 ```
 
 Next, run Mocha as follows: 
@@ -157,7 +158,7 @@ exports.config = {
     },
 
     // ... other Protractor-specific configuration   
-};
+}
 ```
 
 Learn more about supported [Mocha configuration options](https://serenity-js.org/api/mocha-adapter/interface/MochaConfig/).
@@ -187,7 +188,7 @@ export const config = {
     },
 
     // ... other Protractor-specific configuration   
-};
+}
 ```
 
 Learn more about supported [Mocha configuration options](https://serenity-js.org/api/mocha-adapter/interface/MochaConfig/).

--- a/packages/playwright-test/README.md
+++ b/packages/playwright-test/README.md
@@ -9,9 +9,10 @@
 of complex software systems faster, more collaborative and easier to scale.
 
 ⭐️ Get started with Serenity/JS!
-- [Serenity/JS Handbook](https://serenity-js.org/handbook) and [tutorial](https://serenity-js.org/handbook/web-testing/your-first-web-scenario),
-- [API documentation](https://serenity-js.org/api/core),
-- [Serenity/JS project templates on GitHub](https://serenity-js.org/handbook/getting-started#serenityjs-project-templates).
+- [Serenity/JS web testing tutorial](https://serenity-js.org/handbook/web-testing/your-first-web-scenario)
+- [Serenity/JS Handbook](https://serenity-js.org/handbook) and [Getting Started guides](https://serenity-js.org/handbook/getting-started/)
+- [API documentation](https://serenity-js.org/api/core)
+- [Serenity/JS Project Templates on GitHub](https://serenity-js.org/handbook/getting-started#serenityjs-project-templates)
 
 👋 Join the Serenity/JS Community!
 - Meet other Serenity/JS developers and maintainers on the [Serenity/JS Community chat channel](https://matrix.to/#/#serenity-js:gitter.im),
@@ -26,17 +27,19 @@ and fixtures that integrate [Playwright Test](https://playwright.dev/docs/intro)
 
 ### Installation
 
-To install this module, use an existing [Playwright project](https://playwright.dev/docs/intro) or generate a new one by running:
+To install this module, use an existing [Playwright Test project](https://playwright.dev/docs/intro) or generate a new one by running:
 
-```bash
+```sh
 npm init playwright@latest
 ```
 
-Next, run the following command in your Playwright project directory:
+Install the below Serenity/JS modules in your Playwright Test project directory:
 
-```bash
-npm install --save-dev @serenity-js/{assertions,console-reporter,core,serenity-bdd,web,playwright,playwright-test}
+```sh
+npm install --save-dev @serenity-js/assertions @serenity-js/console-reporter @serenity-js/core @serenity-js/serenity-bdd @serenity-js/web @serenity-js/playwright @serenity-js/playwright-test
 ```
+
+To learn more about Serenity/JS and how to use it on your project, follow the [Serenity/JS Getting Started guide for Playwright Test](https://serenity-js.org/handbook/getting-started/serenity-js-with-playwright-test/).
 
 ### Serenity/JS Playwright Fixtures
 
@@ -241,14 +244,14 @@ To get started with component testing:
 
 + const { test, expect } = useBase(componentTest)
 
-import App from './App';
+import App from './App'
 
-test.use({ viewport: { width: 500, height: 500 } });
+test.use({ viewport: { width: 500, height: 500 } })
 
 test('should work', async ({ mount }) => {
-  const component = await mount(<App />);
-  await expect(component).toContainText('Learn React');
-});
+  const component = await mount(<App />)
+  await expect(component).toContainText('Learn React')
+})
 ```
 
 #### Using Serenity/JS Screenplay Pattern Actors for Component Testing
@@ -267,7 +270,7 @@ import { Ensure, contain } from '@serenity-js/assertions'
 import { useBase } from '@serenity-js/playwright-test'
 import { Enter, PageElement, CssClasses } from '@serenity-js/web'
 
-import EmailInput from './EmailInput';
+import EmailInput from './EmailInput'
 
 const { it, describe } = useBase(componentTest).useFixtures<{ emailAddress: string }>({
     emailAddress: ({ actor }, use) => {
@@ -278,9 +281,9 @@ const { it, describe } = useBase(componentTest).useFixtures<{ emailAddress: stri
 describe('EmailInput', () => {
 
     it('allows valid email addresses', async ({ actor, mount, emailAddress }) => {
-        const nativeComponent = await mount(<EmailInput/>);
+        const nativeComponent = await mount(<EmailInput/>)
 
-        const component = PageElement.from(nativeComponent);
+        const component = PageElement.from(nativeComponent)
 
         await actor.attemptsTo(
             Enter.theValue(emailAddress).into(component),
@@ -298,7 +301,7 @@ To use Serenity/JS reporting capabilities, register the `@serenity-js/playwright
 For example, to enable Serenity/JS Console Reporter and Serenity BDD reporter, install the relevant modules:
 
 ```bash
-npm install --save-dev @serenity-js/{console-reporter,serenity-bdd}
+npm install --save-dev @serenity-js/console-reporter @serenity-js/serenity-bdd
 ```
 
 Next, configure your Playwright project as follows:

--- a/packages/playwright/README.md
+++ b/packages/playwright/README.md
@@ -9,9 +9,10 @@
 of complex software systems faster, more collaborative and easier to scale.
 
 ⭐️ Get started with Serenity/JS!
-- [Serenity/JS Handbook](https://serenity-js.org/handbook) and [tutorial](https://serenity-js.org/handbook/web-testing/your-first-web-scenario),
-- [API documentation](https://serenity-js.org/api/core),
-- [Serenity/JS project templates on GitHub](https://serenity-js.org/handbook/getting-started#serenityjs-project-templates).
+- [Serenity/JS web testing tutorial](https://serenity-js.org/handbook/web-testing/your-first-web-scenario)
+- [Serenity/JS Handbook](https://serenity-js.org/handbook) and [Getting Started guides](https://serenity-js.org/handbook/getting-started/)
+- [API documentation](https://serenity-js.org/api/core)
+- [Serenity/JS Project Templates on GitHub](https://serenity-js.org/handbook/getting-started#serenityjs-project-templates)
 
 👋 Join the Serenity/JS Community!
 - Meet other Serenity/JS developers and maintainers on the [Serenity/JS Community chat channel](https://matrix.to/#/#serenity-js:gitter.im),
@@ -29,27 +30,29 @@ for [Playwright](https://playwright.dev/), that helps with testing Web-based app
 To install this module, run the following command in your [Playwright project directory](https://playwright.dev/docs/intro):
 
 ```bash
-npm install --save-dev @serenity-js/{assertions,console-reporter,core,serenity-bdd,web,playwright}
+npm install --save-dev @serenity-js/assertions @serenity-js/console-reporter @serenity-js/core @serenity-js/serenity-bdd @serenity-js/web @serenity-js/playwright
 ```
+
+To learn more about Serenity/JS and how to use it on your project, follow the [Serenity/JS Getting Started guide](https://serenity-js.org/handbook/getting-started/).
 
 ### Usage with Mocha
 
 ```typescript
-import { Ensure, equals } from '@serenity-js/assertions';
-import { actorCalled, Actor, ArtifactArchiver, Cast, configure, Duration } from '@serenity-js/core';
-import { ConsoleReporter } from '@serenity-js/console-reporter';
-import { BrowseTheWebWithPlaywright, PlaywrightOptions } from '@serenity-js/playwright';
-import { SerenityBDDReporter } from '@serenity-js/serenity-bdd';
-import { By, Navigate, PageElement, Photographer, TakePhotosOfFailures, Text } from '@serenity-js/web';
+import { Ensure, equals } from '@serenity-js/assertions'
+import { actorCalled, Actor, ArtifactArchiver, Cast, configure, Duration } from '@serenity-js/core'
+import { ConsoleReporter } from '@serenity-js/console-reporter'
+import { BrowseTheWebWithPlaywright, PlaywrightOptions } from '@serenity-js/playwright'
+import { SerenityBDDReporter } from '@serenity-js/serenity-bdd'
+import { By, Navigate, PageElement, Photographer, TakePhotosOfFailures, Text } from '@serenity-js/web'
 
-import { describe, it, beforeAll, afterAll } from 'mocha';
-import * as playwright from 'playwright';
+import { describe, it, beforeAll, afterAll } from 'mocha'
+import * as playwright from 'playwright'
 
 // example Lean Page Object describing a widget we interact with in the test
 class SerenityJSWebsite {                   
     static header = () => 
         PageElement.located(By.css('h1'))   // selector to identify the interactable element
-            .describedAs('header');         // description to be used in reports
+            .describedAs('header')          // description to be used in reports
 }
 
 // example Actors class, confgures Serenity/JS actors to use Playwright
@@ -64,13 +67,13 @@ class Actors implements Cast {
         return actor.whoCan(
             BrowseTheWebWithPlaywright.using(this.browser, this.options),
             // ... add other abilities as needed, like CallAnApi or TakeNotes
-        );
+        )
     }
 }
 
 describe('Serenity/JS', () => {
 
-    let browser: playwright.Browser;
+    let browser: playwright.Browser
     
     beforeAll(async () => {
         // Start a single browser before all the tests,
@@ -78,7 +81,7 @@ describe('Serenity/JS', () => {
         // and manage Playwright browser context as needed  
         browser = await playwright.chromium.launch({
             headless: true
-        });
+        })
 
         // Configure Serenity/JS providing your Actors
         // and required "stage crew memebers" (a.k.a. reporting services)
@@ -94,8 +97,8 @@ describe('Serenity/JS', () => {
                 new SerenityBDDReporter(),
                 ConsoleReporter.forDarkTerminals(),
             ]
-        });
-    });
+        })
+    })
     
     it('supports Playwright', async () => {
         // actorCalled(name) instantiates or retrieves an existing actor identified by name
@@ -115,8 +118,8 @@ describe('Serenity/JS', () => {
         if (browser) {
             await browser.close()
         }
-    });
-});
+    })
+})
 ```
 
 Next steps:

--- a/packages/playwright/README.md
+++ b/packages/playwright/README.md
@@ -33,7 +33,7 @@ To install this module, run the following command in your [Playwright project di
 npm install --save-dev @serenity-js/assertions @serenity-js/console-reporter @serenity-js/core @serenity-js/serenity-bdd @serenity-js/web @serenity-js/playwright
 ```
 
-To learn more about Serenity/JS and how to use it on your project, follow the [Serenity/JS Getting Started guide](https://serenity-js.org/handbook/getting-started/).
+To learn more about Serenity/JS and how to use it on your project, follow the [Serenity/JS Getting Started guide for Playwright Test](https://serenity-js.org/handbook/getting-started/serenity-js-with-playwright-test/).
 
 ### Usage with Mocha
 

--- a/packages/playwright/README.md
+++ b/packages/playwright/README.md
@@ -33,7 +33,16 @@ To install this module, run the following command in your [Playwright project di
 npm install --save-dev @serenity-js/assertions @serenity-js/console-reporter @serenity-js/core @serenity-js/serenity-bdd @serenity-js/web @serenity-js/playwright
 ```
 
-To learn more about Serenity/JS and how to use it on your project, follow the [Serenity/JS Getting Started guide for Playwright Test](https://serenity-js.org/handbook/getting-started/serenity-js-with-playwright-test/).
+To learn more about Serenity/JS and how to use it on your project, follow the [Serenity/JS Getting Started guide](https://serenity-js.org/handbook/getting-started/).
+
+## Usage with `@playwright/test`
+
+Follow the [Serenity/JS Getting Started guide for Playwright Test](https://serenity-js.org/handbook/getting-started/serenity-js-with-playwright-test/).
+
+## Usage with Cucumber
+
+Follow the [Serenity/JS configuration guide for Cucumber](https://serenity-js.org/handbook/test-runners/cucumber/)
+and review the [Serenity/JS Cucumber and Playwright Project Template](https://github.com/serenity-js/serenity-js-cucumber-playwright-template).
 
 ### Usage with Mocha
 
@@ -126,16 +135,6 @@ Next steps:
 - Add [`@serenity-js/mocha`](https://serenity-js.org/api/mocha/) adapter to produce the reports
 - Learn about the [Screenplay Pattern](https://serenity-js.org/handbook/design/screenplay-pattern.html)
 - Explore [`@serenity-js/web`](https://serenity-js.org/api/web) and [`@serenity-js/assertions`](https://serenity-js.org/api/assertions) APIs
-
-## Usage with `@playwright/test`
-
-See [@serenity-js/playwright-test](https://serenity-js.org/api/playwright-test).
-
-## Usage with Cucumber
-
-Tutorial coming soon! 
-
-Follow [@SerenityJS on Twitter](https://twitter.com/@SerenityJS) to get notified about new tutorials.
 
 ## 📣 Stay up to date
 

--- a/packages/protractor/README.md
+++ b/packages/protractor/README.md
@@ -9,9 +9,10 @@
 of complex software systems faster, more collaborative and easier to scale.
 
 ⭐️ Get started with Serenity/JS!
-- [Serenity/JS Handbook](https://serenity-js.org/handbook) and [tutorial](https://serenity-js.org/handbook/web-testing/your-first-web-scenario),
-- [API documentation](https://serenity-js.org/api/core),
-- [Serenity/JS project templates on GitHub](https://serenity-js.org/handbook/getting-started#serenityjs-project-templates).
+- [Serenity/JS web testing tutorial](https://serenity-js.org/handbook/web-testing/your-first-web-scenario)
+- [Serenity/JS Handbook](https://serenity-js.org/handbook) and [Getting Started guides](https://serenity-js.org/handbook/getting-started/)
+- [API documentation](https://serenity-js.org/api/core)
+- [Serenity/JS Project Templates on GitHub](https://serenity-js.org/handbook/getting-started#serenityjs-project-templates)
 
 👋 Join the Serenity/JS Community!
 - Meet other Serenity/JS developers and maintainers on the [Serenity/JS Community chat channel](https://matrix.to/#/#serenity-js:gitter.im),
@@ -31,13 +32,11 @@ Learn more about [integrating Serenity/JS with Protractor](https://serenity-js.o
 
 To install this module, run:
 
-```console
-npm install --save-dev @serenity-js/{core,protractor}
+```sh
+npm install --save-dev @serenity-js/core @serenity-js/protractor
 ```
 
-Next, install one of the below test runner adapters.
-
-Learn more about [integrating Serenity/JS with Protractor](https://serenity-js.org/handbook/test-runners/protractor/).
+To learn more about Serenity/JS and how to use it on your project, follow the [Serenity/JS Getting Started guide for Protractor](https://serenity-js.org/handbook/getting-started/serenity-js-with-protractor/).
 
 #### Usage with Cucumber.js
 
@@ -78,7 +77,7 @@ const
     { ArtifactArchiver } = require('@serenity-js/core'),
     { ConsoleReporter } = require('@serenity-js/console-reporter'),
     { Photographer, TakePhotosOfFailures, TakePhotosOfInteractions } = require('@serenity-js/protractor'),
-    { SerenityBDDReporter } = require('@serenity-js/serenity-bdd');
+    { SerenityBDDReporter } = require('@serenity-js/serenity-bdd')
 
 exports.config = {
     // Tell Protractor to use the Serenity/JS framework Protractor Adapter
@@ -117,7 +116,7 @@ exports.config = {
     },
 
     // ... other Protractor-specific configuration   
-};
+}
 ```
 
 Learn more about:
@@ -129,17 +128,17 @@ Learn more about:
 ### Interacting with websites and web apps
 
 ```typescript
-import { actorCalled } from '@serenity-js/core';
-import { Ensure, equals } from '@serenity-js/assertions';
-import { By, Navigate, Target, Text } from '@serenity-js/web';
-import { BrowseTheWebWithProtractor } from '@serenity-js/protractor';
-import { protractor } from 'protractor';
+import { actorCalled } from '@serenity-js/core'
+import { Ensure, equals } from '@serenity-js/assertions'
+import { By, Navigate, Target, Text } from '@serenity-js/web'
+import { BrowseTheWebWithProtractor } from '@serenity-js/protractor'
+import { protractor } from 'protractor'
 
 // example Lean Page Object describing a widget we interact with in the test
 class SerenityJSWebsite {
     static header = () =>
         PageElement.located(By.css('h1'))   // selector to identify the interactable element
-            .describedAs('header');         // description to be used in reports
+            .describedAs('header')          // description to be used in reports
 }
 
 // example Jasmine test

--- a/packages/rest/README.md
+++ b/packages/rest/README.md
@@ -9,9 +9,10 @@
 of complex software systems faster, more collaborative and easier to scale.
 
 ⭐️ Get started with Serenity/JS!
-- [Serenity/JS Handbook](https://serenity-js.org/handbook) and [tutorial](https://serenity-js.org/handbook/web-testing/your-first-web-scenario),
-- [API documentation](https://serenity-js.org/api/core),
-- [Serenity/JS project templates on GitHub](https://serenity-js.org/handbook/getting-started#serenityjs-project-templates).
+- [Serenity/JS web testing tutorial](https://serenity-js.org/handbook/web-testing/your-first-web-scenario)
+- [Serenity/JS Handbook](https://serenity-js.org/handbook) and [Getting Started guides](https://serenity-js.org/handbook/getting-started/)
+- [API documentation](https://serenity-js.org/api/core)
+- [Serenity/JS Project Templates on GitHub](https://serenity-js.org/handbook/getting-started#serenityjs-project-templates)
 
 👋 Join the Serenity/JS Community!
 - Meet other Serenity/JS developers and maintainers on the [Serenity/JS Community chat channel](https://matrix.to/#/#serenity-js:gitter.im),
@@ -28,18 +29,20 @@ of complex software systems faster, more collaborative and easier to scale.
 To install this module, as well as [`axios` HTTP client](https://github.com/axios/axios),
 run the following command in your computer terminal:
 
-```console
-npm install --save-dev @serenity-js/{core,rest,assertions} axios
+```sh
+npm install --save-dev @serenity-js/core @serenity-js/rest @serenity-js/assertions axios
 ```
+
+To learn more about Serenity/JS and how to use it on your project, follow the [Serenity/JS Getting Started guide](https://serenity-js.org/handbook/getting-started/).
 
 ### Example test
 
 ```typescript
-import { actorCalled } from '@serenity-js/core';
+import { actorCalled } from '@serenity-js/core'
 import { CallAnApi, DeleteRequest, GetRequest, LastResponse, PostRequest, Send } from '@serenity-js/rest'
-import { Ensure, equals, startsWith } from '@serenity-js/assertions';
+import { Ensure, equals, startsWith } from '@serenity-js/assertions'
 
-const actor = actorCalled('Apisit').whoCan(CallAnApi.at('https://myapp.com/api'));
+const actor = actorCalled('Apisit').whoCan(CallAnApi.at('https://myapp.com/api'))
 
 await actor.attemptsTo(
     // no users present in the system
@@ -58,7 +61,7 @@ await actor.attemptsTo(
     // delete the test user account
     Send.a(DeleteRequest.to(LastResponse.header('Location'))),
     Ensure.that(LastResponse.status(), equals(200)),
-);
+)
 ```
 
 ## 📣 Stay up to date

--- a/packages/serenity-bdd/README.md
+++ b/packages/serenity-bdd/README.md
@@ -9,9 +9,10 @@
 of complex software systems faster, more collaborative and easier to scale.
 
 ⭐️ Get started with Serenity/JS!
-- [Serenity/JS Handbook](https://serenity-js.org/handbook) and [tutorial](https://serenity-js.org/handbook/web-testing/your-first-web-scenario),
-- [API documentation](https://serenity-js.org/api/core),
-- [Serenity/JS project templates on GitHub](https://serenity-js.org/handbook/getting-started#serenityjs-project-templates).
+- [Serenity/JS web testing tutorial](https://serenity-js.org/handbook/web-testing/your-first-web-scenario)
+- [Serenity/JS Handbook](https://serenity-js.org/handbook) and [Getting Started guides](https://serenity-js.org/handbook/getting-started/)
+- [API documentation](https://serenity-js.org/api/core)
+- [Serenity/JS Project Templates on GitHub](https://serenity-js.org/handbook/getting-started#serenityjs-project-templates)
 
 👋 Join the Serenity/JS Community!
 - Meet other Serenity/JS developers and maintainers on the [Serenity/JS Community chat channel](https://matrix.to/#/#serenity-js:gitter.im),
@@ -30,9 +31,11 @@ can then turn into world-class, illustrated test reports and living documentatio
 
 To install this module, run the following command in your computer terminal:
 
-```console
-npm install --save-dev @serenity-js/{core,serenity-bdd}
+```sh
+npm install --save-dev @serenity-js/core @serenity-js/serenity-bdd
 ```
+
+To learn more about Serenity/JS and how to use it on your project, follow the [Serenity/JS Getting Started guide](https://serenity-js.org/handbook/getting-started/).
 
 ### SerenityBDDReporter
 
@@ -51,7 +54,7 @@ Learn more about using [Serenity/JS with Playwright Test](https://serenity-js.or
 
 ```typescript
 // playwright.config.ts
-import type { PlaywrightTestConfig } from '@serenity-js/playwright-test';
+import type { PlaywrightTestConfig } from '@serenity-js/playwright-test'
 
 const config: PlaywrightTestConfig = {
     reporter: [
@@ -65,9 +68,9 @@ const config: PlaywrightTestConfig = {
 
     // Other configuration omitted for brevity
     // For details, see https://playwright.dev/docs/test-configuration    
-};
+}
 
-export default config;
+export default config
 ```
 
 #### Usage with WebdriverIO
@@ -77,7 +80,7 @@ Learn more about using [Serenity/JS with WebdriverIO](https://serenity-js.org/ap
 ```typescript
 // wdio.conf.ts
 
-import { WebdriverIOConfig } from '@serenity-js/webdriverio';
+import { WebdriverIOConfig } from '@serenity-js/webdriverio'
 
 export const config: WebdriverIOConfig = {
 
@@ -92,7 +95,7 @@ export const config: WebdriverIOConfig = {
 
     // Other configuration omitted for brevity
     // For details, see https://webdriver.io/docs/options
-};
+}
 ```
 
 #### Usage with Protractor
@@ -123,15 +126,15 @@ exports.config = {
 Learn more about [configuring Serenity/JS programmatically](https://serenity-js.org/api/core/class/SerenityConfig).
 
 ```typescript
-import { ArtifactArchiver, configure } from '@serenity-js/core';
-import { SerenityBDDReporter } from '@serenity-js/serenity-bdd';
+import { ArtifactArchiver, configure } from '@serenity-js/core'
+import { SerenityBDDReporter } from '@serenity-js/serenity-bdd'
 
 configure({
     crew: [
         ArtifactArchiver.storingArtifactsAt('./target/site/serenity'),
         new SerenityBDDReporter()
     ],
-});
+})
 ```
 
 ### Serenity BDD Living Documentation

--- a/packages/web/README.md
+++ b/packages/web/README.md
@@ -9,9 +9,10 @@
 of complex software systems faster, more collaborative and easier to scale.
 
 ⭐️ Get started with Serenity/JS!
-- [Serenity/JS Handbook](https://serenity-js.org/handbook) and [tutorial](https://serenity-js.org/handbook/web-testing/your-first-web-scenario),
-- [API documentation](https://serenity-js.org/api/core),
-- [Serenity/JS project templates on GitHub](https://serenity-js.org/handbook/getting-started#serenityjs-project-templates).
+- [Serenity/JS web testing tutorial](https://serenity-js.org/handbook/web-testing/your-first-web-scenario)
+- [Serenity/JS Handbook](https://serenity-js.org/handbook) and [Getting Started guides](https://serenity-js.org/handbook/getting-started/)
+- [API documentation](https://serenity-js.org/api/core)
+- [Serenity/JS Project Templates on GitHub](https://serenity-js.org/handbook/getting-started#serenityjs-project-templates)
 
 👋 Join the Serenity/JS Community!
 - Meet other Serenity/JS developers and maintainers on the [Serenity/JS Community chat channel](https://matrix.to/#/#serenity-js:gitter.im),

--- a/packages/webdriverio/README.md
+++ b/packages/webdriverio/README.md
@@ -9,9 +9,10 @@
 of complex software systems faster, more collaborative and easier to scale.
 
 ⭐️ Get started with Serenity/JS!
-- [Serenity/JS Handbook](https://serenity-js.org/handbook) and [tutorial](https://serenity-js.org/handbook/web-testing/your-first-web-scenario),
-- [API documentation](https://serenity-js.org/api/core), 
-- [Serenity/JS project templates on GitHub](https://serenity-js.org/handbook/getting-started#serenityjs-project-templates).
+- [Serenity/JS web testing tutorial](https://serenity-js.org/handbook/web-testing/your-first-web-scenario)
+- [Serenity/JS Handbook](https://serenity-js.org/handbook) and [Getting Started guides](https://serenity-js.org/handbook/getting-started/)
+- [API documentation](https://serenity-js.org/api/core)
+- [Serenity/JS Project Templates on GitHub](https://serenity-js.org/handbook/getting-started#serenityjs-project-templates)
 
 👋 Join the Serenity/JS Community!
 - Meet other Serenity/JS developers and maintainers on the [Serenity/JS Community chat channel](https://matrix.to/#/#serenity-js:gitter.im),
@@ -26,13 +27,19 @@ for [WebdriverIO](https://webdriver.io/) that will help you with testing Web and
 
 ### Installation
 
-To install this module, run the following command in your [WebdriverIO project directory](https://webdriver.io/docs/gettingstarted/):
+To install this module, use an [existing WebdriverIO project](https://webdriver.io/docs/gettingstarted/) or generate a new one by running:
 
-```bash
-npm install --save-dev @serenity-js/{assertions,console-reporter,core,serenity-bdd,web,webdriverio}
+```sh
+npm init wdio .
 ```
 
-Next, install a [Serenity/JS test runner adapter](https://serenity-js.org/handbook/test-runners/) appropriate for your preferred test runner.
+Install the below Serenity/JS modules in your WebdriverIO project directory:
+
+```sh
+npm install --save-dev @serenity-js/assertions @serenity-js/console-reporter @serenity-js/core @serenity-js/serenity-bdd @serenity-js/web @serenity-js/webdriverio
+```
+
+To learn more about Serenity/JS and how to use it on your project, follow the [Serenity/JS Getting Started guide fpr WebdriverIO](https://serenity-js.org/handbook/getting-started/serenity-js-with-webdriverio/).
 
 #### Usage with Cucumber.js
 
@@ -123,7 +130,7 @@ export const config: WebdriverIOConfig = {
     // ],
 
     // ... other WebdriverIO-specific configuration   
-};
+}
 ```
 
 Learn more about:
@@ -144,10 +151,10 @@ with a custom [`Cast`](https://serenity-js.org/api/core/class/Cast), like this o
 
 ```typescript title="serenity/Actors.ts"
 // serenity/Actors.ts
-import { Actor, Cast, TakeNotes } from '@serenity-js/core';
-import { CallAnApi } from '@serenity-js/rest';
-import { BrowseTheWebWithWebdriverIO } from '@serenity-js/webdriverio';
-import type { Browser } from 'webdriverio';
+import { Actor, Cast, TakeNotes } from '@serenity-js/core'
+import { CallAnApi } from '@serenity-js/rest'
+import { BrowseTheWebWithWebdriverIO } from '@serenity-js/webdriverio'
+import type { Browser } from 'webdriverio'
 
 export class Actors implements Cast {
 
@@ -162,13 +169,13 @@ export class Actors implements Cast {
             case 'Apisitt':
                 return actor.whoCan(
                     CallAnApi.at(this.apiUrl)
-                );
+                )
                 
             default:
                 return actor.whoCan(
                     BrowseTheWebWithWebdriverIO.using(browser), // global WDIO browser
                     TakeNotes.usingAnEmptyNotepad(),
-                );
+                )
         }
 
     }
@@ -179,16 +186,16 @@ export class Actors implements Cast {
 
 ```typescript title="specs/example.spec.ts"
 // specs/example.spec.ts
-import { actorCalled } from '@serenity-js/core';
-import { Ensure, equals } from '@serenity-js/assertions';
-import { By, Navigate, PageElement, Text } from '@serenity-js/web';
-import { BrowseTheWebWithWebdriverIO } from '@serenity-js/webdriverio';
+import { actorCalled } from '@serenity-js/core'
+import { Ensure, equals } from '@serenity-js/assertions'
+import { By, Navigate, PageElement, Text } from '@serenity-js/web'
+import { BrowseTheWebWithWebdriverIO } from '@serenity-js/webdriverio'
 
 // example Lean Page Object describing a widget we interact with in the test
 class SerenityJSWebsite {
     static header = () =>
         PageElement.located(By.css('h1'))   // selector to identify the interactable element
-            .describedAs('header');         // description to be used in reports
+            .describedAs('header')          // description to be used in reports
 }
 
 describe('Serenity/JS', () => {
@@ -204,8 +211,8 @@ describe('Serenity/JS', () => {
                     equals('Enable collaborative test automation at any scale!')
                 ),
             )
-    });
-});
+    })
+})
 ```
 
 To learn more, check out the [example projects](https://github.com/serenity-js/serenity-js/tree/main/examples).


### PR DESCRIPTION
Windows terminal doesn't support Bash brace expansion, which means that developers using Windows might have found the installation instructions confusing.

This change makes installation instructions work across macOS, Linux, and Windows.

Related tickets: #1915

<a href="https://gitpod.io/#https://github.com/serenity-js/serenity-js/pull/1916"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

