### PR TITLE
docs(website): add missing space on home page

### DIFF
--- a/documentation/serenity-js.org/src/pages/index.tsx
+++ b/documentation/serenity-js.org/src/pages/index.tsx
@@ -38,7 +38,7 @@ function HeroBanner() {
                 </h1>
                 <p>
                     <strong>Serenity/JS</strong> is an innovative <strong>test automation framework</strong> designed to help you
-                    create <strong>high-quality, business-focused test scenarios</strong> that interact with <strong>any interface of your system</strong>
+                    create <strong>high-quality, business-focused test scenarios</strong> that interact with <strong>any interface of your system</strong> 
                     and produce <strong>comprehensive test reports</strong> that <strong>build trust</strong> between delivery teams and the business.
                 </p>
                 <div className={ styles.indexCtas }>


### PR DESCRIPTION
I perused the front page and noticed a missing space.
![image](https://github.com/serenity-js/serenity-js/assets/25108287/e6e8e822-3d6d-42fc-ae01-41ddc9ca967e)
