### PR TITLE
fix(web): replaced dot in error message by a comma

### DIFF
--- a/packages/web/spec/stage/crew/photographer/Photographer.spec.ts
+++ b/packages/web/spec/stage/crew/photographer/Photographer.spec.ts
@@ -28,6 +28,6 @@ describe('Photographer', () => {
     it('complains when the provided strategy is not valid', () => {
         expect(() => {
             Photographer.fromJSON({ strategy: 'Invalid' } as any);
-        }).to.throw(ConfigurationError, `'Invalid' is not an available PhotoTakingStrategy. Available strategies: TakePhotosBeforeAndAfterInteractions, TakePhotosOfFailures, TakePhotosOfInteractions`);
+        }).to.throw(ConfigurationError, `'Invalid' is not an available PhotoTakingStrategy, available strategies: TakePhotosBeforeAndAfterInteractions, TakePhotosOfFailures, TakePhotosOfInteractions.`);
     });
 });

--- a/packages/web/src/stage/crew/photographer/Photographer.ts
+++ b/packages/web/src/stage/crew/photographer/Photographer.ts
@@ -180,8 +180,8 @@ export class Photographer implements StageCrewMember {
             }
 
             throw new ConfigurationError(
-                `'${ config.strategy }' is not an available PhotoTakingStrategy. ` +
-                `Available strategies: ${ availableStrategies.join(', ') }.`
+                `'${ config.strategy }' is not an available PhotoTakingStrategy, ` +
+                `available strategies: ${ availableStrategies.join(', ') }.`
             );
         }
 


### PR DESCRIPTION
When invalid PhotoTakingStragey was configured, there is an error message. This message is not fully checked by the integration test because of the dot

Found this while experimenting with `PhotoTakingStrategies`:

```
it('complains when the provided strategy is not valid', () => {
        expect(() => {
            Photographer.fromJSON({ strategy: 'Invalid' } as any);
        }).to.throw(ConfigurationError, `'Invalid' is not an available PhotoTakingStrategy, available strategies: TakePhotosBeforeAndAfterInteractions, TakePhotosOfFailures, TakePhotosOfInteractions.`);
    });
```

It looks like the message of the configuration error is just check until the first dot in the message. Everything behind is ignored. Test will pass, even when the enumeration of the available strategies is wrong or missing.