### PR TITLE
docs(core): fixed typo

### DIFF
--- a/documentation/serenity-js.org/docs/reporting/domain-events.mdx
+++ b/documentation/serenity-js.org/docs/reporting/domain-events.mdx
@@ -50,4 +50,4 @@ flowchart TB
 
 You'll typically only need to learn about Serenity/JS domain events when implementing custom reporting services. In this case, you should study:
 - the [`@serenity-js/core/lib/events`](/api/core-events/class/DomainEvent) package, to see what domain events are available,
-- built-in implementations of the [`StageCrewMemeber`](/api/core/interface/StageCrewMember) interface, to see examples of how to work with events.
+- built-in implementations of the [`StageCrewMember`](/api/core/interface/StageCrewMember) interface, to see examples of how to work with events.


### PR DESCRIPTION
Fixes a small typo in documentation.