### PR TITLE
feat(web): actors can now check if an HTML element attribute is present

### DIFF
--- a/integration/web-specs/spec/screenplay/questions/Attribute.spec.ts
+++ b/integration/web-specs/spec/screenplay/questions/Attribute.spec.ts
@@ -1,7 +1,7 @@
 import 'mocha';
 
 import { expect } from '@integration/testing-tools';
-import { Ensure, equals } from '@serenity-js/assertions';
+import { Ensure, equals, isPresent, not } from '@serenity-js/assertions';
 import { actorCalled, LogicError } from '@serenity-js/core';
 import { Attribute, By, Navigate, PageElement, PageElements, Text } from '@serenity-js/web';
 
@@ -23,6 +23,16 @@ describe('Attribute', () => {
         it('allows the actor to read an attribute of a DOM element matching the locator', () =>
             actorCalled('Wendy').attemptsTo(
                 Ensure.that(Attribute.called('lang').of(dom), equals('en')),
+            ));
+
+        it('allows the actor to check if an attribute of a DOM element is present', () =>
+            actorCalled('Wendy').attemptsTo(
+                Ensure.that(Attribute.called('lang').of(dom), isPresent()),
+            ));
+
+        it('allows the actor to check if an attribute of a DOM element is not present', () =>
+            actorCalled('Wendy').attemptsTo(
+                Ensure.that(Attribute.called('data-invalid').of(dom), not(isPresent())),
             ));
 
         it('produces a sensible description of the question being asked', () => {

--- a/packages/web/src/screenplay/questions/Attribute.ts
+++ b/packages/web/src/screenplay/questions/Attribute.ts
@@ -1,4 +1,4 @@
-import type { Answerable, AnswersQuestions, MetaQuestion, MetaQuestionAdapter,QuestionAdapter, UsesAbilities } from '@serenity-js/core';
+import type { Answerable, AnswersQuestions, MetaQuestion, MetaQuestionAdapter, Optional, QuestionAdapter, UsesAbilities } from '@serenity-js/core';
 import { d, LogicError, Question } from '@serenity-js/core';
 
 import { PageElement } from '../models';
@@ -97,7 +97,7 @@ import { PageElement } from '../models';
  */
 export class Attribute<Native_Element_Type>
     extends Question<Promise<string>>
-    implements MetaQuestion<PageElement<Native_Element_Type>, Question<Promise<string>>>
+    implements MetaQuestion<PageElement<Native_Element_Type>, Question<Promise<string>>>, Optional
 {
     private subject: string;
 
@@ -155,6 +155,16 @@ export class Attribute<Native_Element_Type>
         const element = await actor.answer(this.element);
 
         return element.attribute(name);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    isPresent(): QuestionAdapter<boolean> {
+        return Question.about(this.subject, async actor => {
+            const attribute = await this.answeredBy(actor);
+            return attribute !== null && attribute !== undefined;
+        });
     }
 
     /**


### PR DESCRIPTION
Some attributes, like the anchor "download" attribute, do not have a value, so it's more semantically correct to check if they're present rather than that they have an empty value