### PR TITLE
Adding a note about commit messages going into patch notes 

### DIFF
--- a/documentation/serenity-js.org/src/pages/contributing.mdx
+++ b/documentation/serenity-js.org/src/pages/contributing.mdx
@@ -203,6 +203,12 @@ All lines except first will be wrapped after 100 characters.
 
 Once you're happy with the commit message, push your commit to your forked repository, and [raise a pull request](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request).
 
+:::note Your commit messages will be in the changelog
+Please pay attention to what you write in your commit messages, as they're automatically included in the changelog.
+
+If you'd like your pull request to be squashed before it's merged, make sure the title of your PR reflects the change you're proposing. For example `feat(console-reporter): improved stats aggregation`
+:::
+
 :::tip Did you know?
 [Serenity/JS Continuous Delivery Pipeline](https://github.com/serenity-js/serenity-js/blob/main/.github/workflows/main.yaml) implemented using GitHub Actions recognises changes you've marked as `feat` or `fix` and will release them automatically to npmjs.com when your pull request passes the automated tests and gets merged to the main branch by a Serenity/JS maintainer.
 


### PR DESCRIPTION
Hi, I have seem to have a different approach regarding commits, where I create more of them with parts of my work, instead of one for an entire functionality. When I have seen the patchnotes for 3.19, I noticed it'd be quite confusing to see patch note with "reverting to previous functionality"

That's why I added a note for that in the docs 😄 
<img width="851" alt="Screenshot 2024-03-01 at 17 34 49" src="https://github.com/serenity-js/serenity-js/assets/39599512/d05e3ce7-bc80-4680-bcd2-847098761c32">

@jan-molak 