### PR TITLE
feat(core): simplified reading and writing files in CrewMembers using the FileSystem

### DIFF
--- a/packages/core/spec/FakeFS.ts
+++ b/packages/core/spec/FakeFS.ts
@@ -1,44 +1,12 @@
-import fs = require('fs');
-import path = require('upath');
-// eslint-disable-next-line @typescript-eslint/no-var-requires
-const { createFsFromVolume, Volume } = require('memfs'); // Typings incorrectly assume the presence of "dom" lib
+import type * as fs from 'node:fs';
 
-export interface DirectoryStructure {
-    [ key: string ]: DirectoryStructure | string;
-}
+import type { NestedDirectoryJSON} from 'memfs';
+import { createFsFromVolume, Volume } from 'memfs';
 
 export class FakeFS {
     public static readonly Empty_Directory = {};
 
-    static with(tree: DirectoryStructure, cwd = process.cwd()): typeof fs {
-
-        function flatten(
-            currentStructure: DirectoryStructure | string,
-            currentPath = '',
-        ): { [key: string]: string } {
-
-            if (typeof currentStructure === 'string') {
-                return ({
-                    [ currentPath ]: currentStructure,
-                });
-            }
-
-            const entries = Object.keys(currentStructure);
-
-            if (entries.length === 0) {
-                return ({
-                    [ currentPath ]: void 0,
-                });
-            }
-
-            return Object.keys(currentStructure).reduce((acc, key) =>  {
-                return ({
-                    ...acc,
-                    ...flatten(currentStructure[key], path.join(currentPath, key)),
-                });
-            }, {});
-        }
-
-        return createFsFromVolume(Volume.fromJSON(flatten(tree), cwd)) as typeof fs;
+    static with(tree: NestedDirectoryJSON, cwd = process.cwd()): typeof fs {
+        return createFsFromVolume(Volume.fromNestedJSON(tree, cwd)) as unknown as typeof fs;
     }
 }

--- a/packages/core/spec/io/Version.spec.ts
+++ b/packages/core/spec/io/Version.spec.ts
@@ -1,4 +1,5 @@
 import { describe, it } from 'mocha';
+import { given } from 'mocha-testdata';
 
 import { Version } from '../../src/io';
 import { expect } from '../expect';
@@ -9,11 +10,65 @@ describe('Version', () => {
         expect(new Version('1.2.3').isAtLeast(new Version('1.0.0'))).to.equal(true);
     });
 
-    it('grants access to the major version number', () => {
+    it('tells the major version number', () => {
         expect(new Version('1.2.3').major()).to.equal(1);
     });
 
     it('provides a sensible description', () => {
         expect(new Version('1.2.3').toString()).to.equal('1.2.3');
+    });
+
+    given([
+        { range: '1.x', expected: true },
+        { range: '0.x || >=1.2', expected: true },
+        { range: '^1', expected: true },
+        { range: '0.x || 2.x', expected: false },
+    ]).
+    it('checks if the version satisfies a given range', ({ range, expected }) => {
+        expect(new Version('1.2.3').satisfies(range)).to.equal(expected);
+    });
+
+    given([
+        { version: '1.2.2', expected: true },
+        { version: '1.2.3', expected: false },
+        { version: '1.2.4', expected: false },
+    ]).
+    it('tells if it is lower than another version', ({ version, expected }) => {
+        expect(new Version(version).isLowerThan(new Version('1.2.3'))).to.equal(expected);
+    });
+
+    given([
+        { version: '1.2.2', expected: true },
+        { version: '1.2.3', expected: true },
+        { version: '1.2.4', expected: false },
+    ]).
+    it('tells if it is at most another version', ({ version, expected }) => {
+        expect(new Version(version).isAtMost(new Version('1.2.3'))).to.equal(expected);
+    });
+
+    given([
+        { version: '1.2.2', expected: false },
+        { version: '1.2.3', expected: true },
+        { version: '1.2.4', expected: true },
+    ]).
+    it('tells if it is at least another version', ({ version, expected }) => {
+        expect(new Version(version).isAtLeast(new Version('1.2.3'))).to.equal(expected);
+    });
+
+    given([
+        { version: '1.2.2', expected: false },
+        { version: '1.2.3', expected: false },
+        { version: '1.2.4', expected: true },
+    ]).
+    it('tells if it is higher than another version', ({ version, expected }) => {
+        expect(new Version(version).isHigherThan(new Version('1.2.3'))).to.equal(expected);
+    });
+
+    it('tells if it is equal to another version', () => {
+        expect(new Version('1.2.3').equals(new Version('1.2.3'))).to.equal(true);
+    });
+
+    it('can be created from a JSON string', () => {
+        expect(Version.fromJSON('1.2.3')).to.equal(new Version('1.2.3'));
     });
 });

--- a/packages/core/src/io/Version.ts
+++ b/packages/core/src/io/Version.ts
@@ -1,0 +1,61 @@
+import semver from 'semver';
+import { ensure, isDefined, isString, Predicate, TinyType } from 'tiny-types';
+
+/**
+ * A tiny type describing a version number, like `1.2.3`
+ */
+export class Version extends TinyType {
+
+    static fromJSON(version: string): Version {
+        return new Version(version);
+    }
+
+    constructor(private readonly version: string) {
+        super();
+        ensure('version', version, isDefined(), isString(), isValid());
+    }
+
+    isLowerThan(other: Version): boolean {
+        return semver.lt(this.version, other.version, { loose: false });
+    }
+
+    isAtMost(other: Version): boolean {
+        return semver.lte(this.version, other.version, { loose: false });
+    }
+
+    /**
+     * @param other
+     */
+    isAtLeast(other: Version): boolean {
+        return semver.gte(this.version, other.version, { loose: false });
+    }
+
+    isHigherThan(other: Version): boolean {
+        return semver.gt(this.version, other.version, { loose: false });
+    }
+
+    /**
+     * @returns
+     *  Major version number of a given package version, i.e. `1` in `1.2.3`
+     */
+    major(): number {
+        return Number(this.version.split('.')[0]);
+    }
+
+    satisfies(range: string): boolean {
+        return semver.satisfies(this.version, range, { loose: false });
+    }
+
+    toString(): string {
+        return `${ this.version }`;
+    }
+}
+
+/**
+ * @package
+ */
+function isValid(): Predicate<string> {
+    return Predicate.to(`be a valid version number`, (version: string) =>
+        !! semver.valid(version),
+    );
+}

--- a/packages/core/src/io/index.ts
+++ b/packages/core/src/io/index.ts
@@ -12,3 +12,4 @@ export * from './Path';
 export * from './reflection';
 export * from './RequirementsHierarchy';
 export * from './trimmed';
+export * from './Version';

--- a/packages/core/src/io/loader/index.ts
+++ b/packages/core/src/io/loader/index.ts
@@ -2,4 +2,3 @@ export * from './ClassDescriptionParser';
 export * from './ClassDescriptor';
 export * from './ClassLoader';
 export * from './ModuleLoader';
-export * from './Version';


### PR DESCRIPTION
Being able to directly read files from the file system in crew members should enable services like the ConsoleReporter to display code snippets and will enable refactoring the artifact handling mechanism in the SerenityBDDReporter

Related tickets: re #2244