### PR TITLE
feat(serenity-bdd): include Serenity BDD CLI jar file into files of the published package

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -28,7 +28,7 @@ jobs:
       npm-install-command: make BOOTSTRAP_SCOPE=libs install
       command: make COMPILE_SCOPE=libs compile
       upload-artifact-name: 'compiled-libs'
-      upload-artifact-path: 'package.json "integration/*/lib/*" "packages/*/lib/*" "packages/*/esm/*"'
+      upload-artifact-path: 'package.json "integration/*/lib/*" "packages/*/lib/*" "packages/*/esm/*" "packages/serenity-bdd/cache/*"'
 
   #
   # Test

--- a/integration/playwright-web/package.json
+++ b/integration/playwright-web/package.json
@@ -19,8 +19,7 @@
   ],
   "scripts": {
     "clean": "rimraf target",
-    "test": "failsafe clean test:update-serenity test:acceptance test:report",
-    "test:update-serenity": "serenity-bdd update --ignoreSSL",
+    "test": "failsafe clean test:acceptance test:report",
     "test:acceptance": "cross-env PORT=8082 start-server-and-test start http://localhost:8082 test:acceptance:run",
     "start": "npx web-specs-start",
     "test:acceptance:run": "c8 mocha --config .mocharc.yml",

--- a/integration/protractor-web/package.json
+++ b/integration/protractor-web/package.json
@@ -19,8 +19,7 @@
   ],
   "scripts": {
     "clean": "rimraf target",
-    "test": "failsafe clean test:update-serenity test:acceptance test:report",
-    "test:update-serenity": "serenity-bdd update --ignoreSSL",
+    "test": "failsafe clean test:acceptance test:report",
     "test:acceptance": "cross-env PORT=8081 start-server-and-test start http://localhost:8081 test:acceptance:run",
     "start": "npx web-specs-start",
     "test:acceptance:run": "c8 protractor protractor.conf.js",

--- a/integration/webdriverio-web/package.json
+++ b/integration/webdriverio-web/package.json
@@ -21,7 +21,6 @@
     "clean": "rimraf target",
     "test:devtools": "cross-env PROTOCOL=devtools npm test",
     "test:webdriver": "cross-env PROTOCOL=webdriver npm test",
-    "pretest": "serenity-bdd update --ignoreSSL",
     "test": "cross-env PORT=8080 failsafe clean test:acceptance test:report",
     "test:acceptance": "start-server-and-test start 'http://localhost:8080' test:acceptance:run",
     "start": "npx web-specs-start",

--- a/packages/serenity-bdd/package.json
+++ b/packages/serenity-bdd/package.json
@@ -38,7 +38,9 @@
     "clean": "rimraf target",
     "test": "c8 npm run test:no-coverage",
     "test:no-coverage": "mocha --config ../../.mocharc.yml 'spec/**/*.spec.*'",
-    "compile": "rimraf lib && tsc --project tsconfig.build.json"
+    "compile": "rimraf lib && tsc --project tsconfig.build.json",
+    "postcompile": "npm run populate-cache",
+    "populate-cache": "node ./bin/serenity-bdd update --ignoreSSL --cacheDir './cache'"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
This change should simplify overall setup experience for most of the cases by eleminating the need to run "serenity-bdd update" manually. Default version of Serenity BDD will be saved into default directory and will be included into files under the default path of the package and published to NPM registry.

This change does not affect current customization capabilities in any way, it's still possible to set custom cache directory or set specific version of Serenity BDD.

Related tickets: #2560