### PR TITLE
docs(website): fix an inconsistency in an example in the Question API…

### DIFF
--- a/packages/core/src/screenplay/Question.ts
+++ b/packages/core/src/screenplay/Question.ts
@@ -45,7 +45,7 @@ import type { WithAnswerableProperties } from './WithAnswerableProperties';
  *    });
  *
  *  await actorCalled('Quentin').attemptsTo(
- *    Ensure.that(LastItemFrom([1,2,3]), equals(3)),
+ *    Ensure.that(LastItemOf([1,2,3]), equals(3)),
  *  )
  * ```
  *


### PR DESCRIPTION
While I was trying to deepen my understanding of questions, I noticed this typo, so I fixed it. In one place it said `LastItemOf`, in the other it said `LastItemFrom`.