### PR TITLE
fix(serenity-bdd): escape HTML entities in scenario parameter descriptions

### DIFF
--- a/packages/serenity-bdd/spec/stage/crew/serenity-bdd-reporter/SerenityBDDReporter/describing_scene.spec.ts
+++ b/packages/serenity-bdd/spec/stage/crew/serenity-bdd-reporter/SerenityBDDReporter/describing_scene.spec.ts
@@ -56,6 +56,23 @@ describe('SerenityBDDReporter', () => {
             });
     });
 
+    it('escapes HTML entities in background title and description', () => {
+        stage.announce(
+            new SceneStarts(sceneId, defaultCardScenario),
+            new SceneBackgroundDetected(sceneId, new Name(`Background title <script>alert('xss')</script>`), new Description(`Background description <script>alert('xss')</script>`)),
+            new SceneFinished(sceneId, defaultCardScenario, new ExecutionSuccessful()),
+            new TestRunFinishes(),
+        );
+
+        PickEvent.from(recorder.events)
+            .last(ArtifactGenerated, event => {
+                const report = event.artifact.map(_ => _);
+
+                expect(report.backgroundTitle).to.equal('Background title &lt;script&gt;alert(&apos;xss&apos;)&lt;/script&gt;');
+                expect(report.backgroundDescription).to.equal('Background description &lt;script&gt;alert(&apos;xss&apos;)&lt;/script&gt;');
+            });
+    });
+
     it('captures the description of the scenario', () => {
         stage.announce(
             new SceneStarts(sceneId, defaultCardScenario),
@@ -85,6 +102,22 @@ describe('SerenityBDDReporter', () => {
                 const report = event.artifact.map(_ => _);
 
                 expect(report.userStory.narrative).to.equal('Feature narrative');
+            });
+    });
+
+    it('escapes HTML entities in narrative description', () => {
+        stage.announce(
+            new SceneStarts(sceneId, defaultCardScenario),
+            new FeatureNarrativeDetected(sceneId, new Description(`Feature narrative <script>alert('xss')</script>`)),
+            new SceneFinished(sceneId, defaultCardScenario, new ExecutionSuccessful()),
+            new TestRunFinishes(),
+        );
+
+        PickEvent.from(recorder.events)
+            .last(ArtifactGenerated, event => {
+                const report = event.artifact.map(_ => _);
+
+                expect(report.userStory.narrative).to.equal('Feature narrative &lt;script&gt;alert(&apos;xss&apos;)&lt;/script&gt;');
             });
     });
 

--- a/packages/serenity-bdd/src/stage/crew/serenity-bdd-reporter/processors/scene-sequence/transformations/scenarioParametersOf.ts
+++ b/packages/serenity-bdd/src/stage/crew/serenity-bdd-reporter/processors/scene-sequence/transformations/scenarioParametersOf.ts
@@ -1,6 +1,7 @@
 import type { ScenarioDetails, ScenarioParameters } from '@serenity-js/core/lib/model';
 
 import type { DataTableDataSetDescriptorSchema, DataTableSchema } from '../../../serenity-bdd-report-schema';
+import { escapeHtml } from '../../mappers';
 import type { SceneSequenceReportContext } from '../SceneSequenceReportContext';
 
 export function scenarioParametersOf(scenario: ScenarioDetails, parameters: ScenarioParameters): (context: SceneSequenceReportContext) => SceneSequenceReportContext {
@@ -16,8 +17,8 @@ export function scenarioParametersOf(scenario: ScenarioDetails, parameters: Scen
         }
 
         const newDescriptor = {
-            name:           parameters.name.value,
-            description:    parameters.description && parameters.description.value,
+            name:           escapeHtml(parameters.name.value),
+            description:    escapeHtml(parameters.description && parameters.description.value),
             startRow:       dataTable.dataSetDescriptors.reduce((acc, current) => acc + current.rowCount, 0),
             rowCount:       0,
         };

--- a/packages/serenity-bdd/src/stage/crew/serenity-bdd-reporter/processors/transformations/backgroundOf.ts
+++ b/packages/serenity-bdd/src/stage/crew/serenity-bdd-reporter/processors/transformations/backgroundOf.ts
@@ -1,5 +1,6 @@
 import type { Description, Name } from '@serenity-js/core/lib/model';
 
+import { escapeHtml } from '../mappers';
 import type { SerenityBDDReportContext } from '../SerenityBDDReportContext';
 
 /**
@@ -8,8 +9,8 @@ import type { SerenityBDDReportContext } from '../SerenityBDDReportContext';
 export function backgroundOf<Context extends SerenityBDDReportContext>(name: Name, description: Description): (context: Context) => Context {
     return (context: Context): Context => {
 
-        context.report.backgroundTitle = name.value;
-        context.report.backgroundDescription = description.value;
+        context.report.backgroundTitle = escapeHtml(name.value);
+        context.report.backgroundDescription = escapeHtml(description.value);
 
         return context;
     }

--- a/packages/serenity-bdd/src/stage/crew/serenity-bdd-reporter/processors/transformations/businessRuleOf.ts
+++ b/packages/serenity-bdd/src/stage/crew/serenity-bdd-reporter/processors/transformations/businessRuleOf.ts
@@ -1,5 +1,6 @@
 import type { BusinessRule } from '@serenity-js/core/lib/model';
 
+import { escapeHtml } from '../mappers';
 import type { SerenityBDDReportContext } from '../SerenityBDDReportContext';
 
 /**
@@ -9,8 +10,8 @@ export function businessRuleOf<Context extends SerenityBDDReportContext>(rule: B
     return (context: Context): Context => {
 
         context.report.rule = {
-            name: rule.name.value,
-            description: rule.description.value,
+            name: escapeHtml(rule.name.value),
+            description: escapeHtml(rule.description.value),
         };
 
         return context;

--- a/packages/serenity-bdd/src/stage/crew/serenity-bdd-reporter/processors/transformations/descriptionOf.ts
+++ b/packages/serenity-bdd/src/stage/crew/serenity-bdd-reporter/processors/transformations/descriptionOf.ts
@@ -1,5 +1,6 @@
 import type { Description } from '@serenity-js/core/lib/model';
 
+import { escapeHtml } from '../mappers';
 import type { SerenityBDDReportContext } from '../SerenityBDDReportContext';
 
 /**
@@ -8,7 +9,7 @@ import type { SerenityBDDReportContext } from '../SerenityBDDReportContext';
 export function descriptionOf<Context extends SerenityBDDReportContext>(description: Description): (context: Context) => Context {
     return (context: Context): Context => {
 
-        context.report.description = description.value;
+        context.report.description = escapeHtml(description.value);
 
         return context;
     }

--- a/packages/serenity-bdd/src/stage/crew/serenity-bdd-reporter/processors/transformations/featureNarrativeOf.ts
+++ b/packages/serenity-bdd/src/stage/crew/serenity-bdd-reporter/processors/transformations/featureNarrativeOf.ts
@@ -1,5 +1,6 @@
 import type { Description } from '@serenity-js/core/lib/model';
 
+import { escapeHtml } from '../mappers';
 import type { SerenityBDDReportContext } from '../SerenityBDDReportContext';
 
 /**
@@ -9,7 +10,7 @@ export function featureNarrativeOf<Context extends SerenityBDDReportContext>(des
     return (context: Context): Context => {
         context.report.userStory = {
             ...context.report.userStory,
-            narrative: description.value,
+            narrative: escapeHtml(description.value),
         }
 
         return context;


### PR DESCRIPTION
All the parameters, business rules, feature narratives, and similar descriptions now have HTML entities correctly escaped to prevent formatting errors and potential script injection attacks. Thanks to @softwaretestingcentre for identifying the issue!

Closes #2879