### PR TITLE
Potential fix for code scanning alert no. 66: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/chore-delete-old-workflows.yaml
+++ b/.github/workflows/chore-delete-old-workflows.yaml
@@ -1,4 +1,7 @@
 name: "Chore: Delete old workflows"
+permissions:
+  contents: read
+  actions: write
 on:
   schedule:
     # Run daily, at 19:14


### PR DESCRIPTION
Potential fix for [https://github.com/serenity-js/serenity-js/security/code-scanning/66](https://github.com/serenity-js/serenity-js/security/code-scanning/66)

To fix the issue, add a `permissions` block to the workflow to explicitly define the least privileges required for the task. Since the workflow deletes old workflow runs, it likely requires `contents: read` to access repository contents and `actions: write` to delete workflow runs. This ensures that the `GITHUB_TOKEN` has only the necessary permissions, reducing the risk of unintended actions.

The `permissions` block should be added at the root level of the workflow to apply to all jobs, as there is only one job in this workflow. Alternatively, it could be added specifically to the `delete_old_workflows` job.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
