### PR TITLE
fix(core): internal - refactored Tag deserialiser to simplify the import graph

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -308,6 +308,7 @@ jobs:
       - test-integration-webdriverio
     runs-on: ubuntu-24.04
     permissions:
+      checks: write
       contents: read
       id-token: write
     steps:

--- a/packages/core/spec/model/Tag.spec.ts
+++ b/packages/core/spec/model/Tag.spec.ts
@@ -59,7 +59,7 @@ describe('Tag', () => {
         new ThemeTag('sales'),
     ]).
     it('can be deserialised from a JSON object', (tag: Tag) => {
-        expect(Tag.fromJSON(tag.toJSON())).to.equal(tag);
+        expect(Tags.fromJSON(tag.toJSON())).to.equal(tag);
     });
 
     given([

--- a/packages/core/src/events/SceneTagged.ts
+++ b/packages/core/src/events/SceneTagged.ts
@@ -1,7 +1,7 @@
 import type { JSONObject } from 'tiny-types';
 import { ensure, isDefined } from 'tiny-types';
 
-import { CorrelationId, Tag } from '../model';
+import { CorrelationId, type Tag, Tags } from '../model';
 import { Timestamp } from '../screenplay';
 import { DomainEvent } from './DomainEvent';
 
@@ -12,7 +12,7 @@ export class SceneTagged extends DomainEvent {
     static fromJSON(o: JSONObject): SceneTagged {
         return new SceneTagged(
             CorrelationId.fromJSON(o.sceneId as string),
-            Tag.fromJSON(o.tag as JSONObject),
+            Tags.fromJSON(o.tag as JSONObject),
             Timestamp.fromJSON(o.timestamp as string),
         );
     }

--- a/packages/core/src/instance.ts
+++ b/packages/core/src/instance.ts
@@ -14,10 +14,8 @@ const clock = new Clock();
 export const serenity = new Serenity(clock);
 
 /**
- * Configures Serenity/JS. Every call to this function
- * replaces the previous configuration provided,
- * so this function should be called exactly once
- * in your test suite.
+ * Configures Serenity/JS. Every call to this function replaces the previous configuration provided,
+ * so this function should be called exactly once in your test suite.
  *
  * This function is an alias for [`Serenity.configure`](https://serenity-js.org/api/core/class/Serenity/#configure).
  *

--- a/packages/core/src/model/tags/Tag.ts
+++ b/packages/core/src/model/tags/Tag.ts
@@ -1,7 +1,4 @@
-import type { JSONObject} from 'tiny-types';
-import { ensure, isDefined, isGreaterThan, isString, property, TinyType } from 'tiny-types';
-
-import * as TagTypes from './index';
+import { ensure, isDefined, isGreaterThan, property, TinyType } from 'tiny-types';
 
 /**
  * @access public

--- a/packages/core/src/model/tags/Tag.ts
+++ b/packages/core/src/model/tags/Tag.ts
@@ -20,18 +20,6 @@ export abstract class Tag extends TinyType {
         return new tagConstructor(name.charAt(0).toUpperCase() + name.slice(1));
     }
 
-    static fromJSON(o: JSONObject): Tag {
-        const type: string = ensure('serialised tag type', o.type, isDefined(), isString()) as string;
-
-        const found = Object.keys(TagTypes).find(t => TagTypes[t].Type === type) || TagTypes.ArbitraryTag.name;
-
-        if (Object.prototype.hasOwnProperty.call(TagTypes[found], 'fromJSON')) {
-            return TagTypes[found].fromJSON(o);
-        }
-
-        return new TagTypes[found](o.name);
-    }
-
     protected constructor(public readonly name: string, public readonly type: string) {
         super();
 

--- a/packages/core/src/model/tags/Tags.ts
+++ b/packages/core/src/model/tags/Tags.ts
@@ -9,6 +9,7 @@ import { FeatureTag } from './FeatureTag';
 import { IssueTag } from './IssueTag';
 import { ManualTag } from './ManualTag';
 import { PlatformTag } from './PlatformTag';
+import { ProjectTag } from './ProjectTag';
 import type { Tag } from './Tag';
 import { ThemeTag } from './ThemeTag';
 
@@ -33,6 +34,7 @@ export class Tags {
         IssueTag,
         ManualTag,
         PlatformTag,
+        ProjectTag,
         ThemeTag,
     ].map(tagType => [ tagType.Type, tagType ]))
 

--- a/packages/core/src/model/tags/Tags.ts
+++ b/packages/core/src/model/tags/Tags.ts
@@ -1,12 +1,41 @@
-import { match } from 'tiny-types';
+import type { JSONObject, JSONValue } from 'tiny-types';
+import { ensure, isDefined, isString, match } from 'tiny-types';
 
-import type { Tag } from './';
-import { ArbitraryTag, IssueTag, ManualTag } from './';
+import { ArbitraryTag } from './ArbitraryTag';
+import { BrowserTag } from './BrowserTag';
+import { CapabilityTag } from './CapabilityTag';
+import { ExecutionRetriedTag } from './ExecutionRetriedTag';
+import { FeatureTag } from './FeatureTag';
+import { IssueTag } from './IssueTag';
+import { ManualTag } from './ManualTag';
+import { PlatformTag } from './PlatformTag';
+import type { Tag } from './Tag';
+import { ThemeTag } from './ThemeTag';
+
+interface Deserialiser<Return_Type> {
+    fromJSON(o: JSONValue): Return_Type;
+}
+
+function hasCustomDeserialiser(tagType: any): tagType is Deserialiser<Tag> {
+    return Object.prototype.hasOwnProperty.call(tagType, 'fromJSON');
+}
 
 /**
  * @package
  */
 export class Tags {
+    private static readonly supportedTypes: Map<string, Deserialiser<Tag> | { new (name: string): Tag }> = new Map([
+        ArbitraryTag,
+        BrowserTag,
+        CapabilityTag,
+        ExecutionRetriedTag,
+        FeatureTag,
+        IssueTag,
+        ManualTag,
+        PlatformTag,
+        ThemeTag,
+    ].map(tagType => [ tagType.Type, tagType ]))
+
     private static Pattern = /^@([\w-]+)[\s:]?(.*)/i;
 
     private static matchTags(tagText: string): Tag[] {
@@ -20,6 +49,22 @@ export class Tags {
             .when('manual', _ => [ new ManualTag() ])
             .when(/^issues?$/, _ => value.split(',').map(value => new IssueTag(value.trim())))
             .else(value => [ new ArbitraryTag(value.trim()) ]);
+    }
+
+    static fromJSON(o: JSONObject): Tag {
+        const type: string = ensure('serialised tag type', o.type, isDefined(), isString()) as string;
+
+        if (! this.supportedTypes.has(type)) {
+            return new ArbitraryTag(o.name as string);
+        }
+
+        const found = this.supportedTypes.get(type);
+
+        if (hasCustomDeserialiser(found)) {
+            return found.fromJSON(o);
+        }
+
+        return new found(o.name as string);
     }
 
     public static from(text: string): Tag[] {


### PR DESCRIPTION
Previously, a serialised `Tag` object would be deserialised by calling `Tag.fromJSON`. This method would then internally call the appropriate tag constructor function. While this approach works, it creates a sub-optimal import graph as Tag relies on all the tags that implement it, and in turn, all the tags rely on Tag. This import graph confuses some TypeScript transpilers and requires simplifying.

In this PR, I moved the `toJSON` method from `Tag` to `Tags` to simplify the import graph.