### PR TITLE
feat(web): support for identifying page elements by their ARIA role and name

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -23,7 +23,6 @@
       "matchPackageNames": [
         "/@paralleldrive/cuid2/",
         "/@types/diff/",
-        "/@types/filenamify/",
         "/@types/validate-npm-package-name/",
         "/assertion-error-formatter/",
         "/diff/",

--- a/integration/protractor-web/protractor.conf.js
+++ b/integration/protractor-web/protractor.conf.js
@@ -8,6 +8,9 @@ exports.config = {
         './node_modules/@integration/web-specs/spec/**/*.spec.ts',
         './spec/**/*.spec.ts',
     ],
+    exclude: [
+        './node_modules/@integration/web-specs/spec/**/PageElement.located.ByRole.spec.ts'
+    ],
 
     baseUrl: `http://localhost:${ process.env.PORT || 8080 }`,
     framework:      'custom',

--- a/integration/web-specs/spec/screenplay/models/PageElement.located.ByRole.spec.ts
+++ b/integration/web-specs/spec/screenplay/models/PageElement.located.ByRole.spec.ts
@@ -1,0 +1,101 @@
+import 'mocha';
+
+import { expect } from '@integration/testing-tools';
+import { Ensure, equals, isPresent, startsWith } from '@serenity-js/assertions';
+import { actorCalled, Question } from '@serenity-js/core';
+import { By, Navigate, PageElement, Text } from '@serenity-js/web';
+import { Attribute } from '@serenity-js/web';
+
+/** @test {PageElement} */
+describe('PageElement', () => {
+
+    // eslint-disable-next-line unicorn/consistent-function-scoping
+    const question = <T>(name: string, value: T) =>
+        Question.about(name, _actor => value);
+
+    describe('when locating an element', () => {
+
+        describe('by role', () => {
+
+            const Elements = {
+                submitButton:   PageElement.located(By.role('button', { name: 'Submit' })).describedAs('submit button'),
+                textbox:        PageElement.located(By.role('textbox', { name: 'Email Address' })).describedAs('email address textbox'),
+                checkbox:       PageElement.located(By.role('checkbox', { name: 'Subscribe' })).describedAs('subscribe checkbox'),
+                heading:        PageElement.located(By.role('heading', { name: 'Fruits List', level: 2 })).describedAs('fruits list heading with leading and trailing whitespace'),
+                list:           PageElement.located(By.role('list')).describedAs('fruits list'),
+                listItem:       PageElement.located(By.role('listitem', { name: 'Apple' })).describedAs('apple list item'),
+                homeLink:       PageElement.located(By.role('link', { name: 'Home' })).describedAs('home link with explicit aria role'),
+                aboutLink:      PageElement.located(By.role('link', { name: 'About' })).describedAs('about link with no explicit aria role'),
+                alert:          PageElement.located(By.role('alert')).describedAs('alert message'),
+                progressbar:    PageElement.located(By.role('progressbar')).describedAs('loading progress bar'),
+                navigation:     PageElement.located(By.role('navigation', { name: 'Main menu' })).describedAs('main menu navigation'),
+                banner:         PageElement.located(By.role('banner')).describedAs('page banner'),
+                main:           PageElement.located(By.role('main')).describedAs('main content area'),
+                form:           PageElement.located(By.role('form', { name: 'Signup' })).describedAs('signup form'),
+                someButton:     PageElement.located(By.role('button', { name: 'Some_button' })).describedAs('some button'),
+            };
+
+            beforeEach(() =>
+                actorCalled('Elle').attemptsTo(
+                    Navigate.to('/screenplay/models/page-element/by_role.html'),
+                ));
+
+            it('generates a description for a PageElement without a custom description', () => {
+                expect(PageElement.located(By.role('button', { name: 'Submit' })).toString())
+                    .to.equal(`page element located by role "button" (name: 'Submit')`)
+            });
+
+            it('generates a description for a PageElement without a custom description, where the selector is provided as question', () => {
+                expect(PageElement.located(By.role('button', { name: question('button name', 'Submit') })).toString())
+                    .to.equal(`page element located by role "button" (name: <<button name>>)`);
+            });
+
+            it('uses a custom description when provided', () => {
+                expect(PageElement.located(By.role('button', { name: 'Submit' })).describedAs('the confirmation button').toString())
+                    .to.equal(`the confirmation button`);
+            });
+
+            it('can locate an element by its role alone', async () => {
+                await actorCalled('Elle').attemptsTo(
+                    Ensure.that(Elements.banner, isPresent()),
+                );
+            });
+
+            it('can locate a button by its role and name', async () => {
+                await actorCalled('Elle').attemptsTo(
+                    Ensure.that(Elements.submitButton, isPresent()),
+                );
+            });
+
+            it('can locate an input by its aria label', async () => {
+                await actorCalled('Elle').attemptsTo(
+                    Ensure.that(Elements.checkbox, isPresent()),
+                );
+            });
+
+            it('can locate a heading by its role, name and level', async () => {
+                await actorCalled('Elle').attemptsTo(
+                    Ensure.that(Text.of(Elements.heading), equals('Fruits List')),
+                );
+            });
+
+            it('can locate a button by its aria-labelledby property', async () => {
+                await actorCalled('Elle').attemptsTo(
+                    Ensure.that(Text.of(Elements.someButton), equals('Click Me!')),
+                );
+            });
+
+            it('can locate an element by its aria-label property', async () => {
+                await actorCalled('Elle').attemptsTo(
+                    Ensure.that(Elements.navigation.html(), startsWith('<nav role="navigation" aria-label="Main menu">')),
+                );
+            });
+
+            it('can locate an element by its role and content', async () => {
+                await actorCalled('Elle').attemptsTo(
+                    Ensure.that(Attribute.called('href').of(Elements.homeLink), equals('#home')),
+                );
+            });
+        });
+    });
+});

--- a/integration/web-specs/static/screenplay/models/page-element/by_role.html
+++ b/integration/web-specs/static/screenplay/models/page-element/by_role.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8" />
+    <title>Serenity/JS By.role() examples</title>
+</head>
+<body>
+<header role="banner">
+    <h1>App Demo</h1>
+</header>
+
+<nav role="navigation" aria-label="Main menu">
+    <ul>
+        <li><a href="#home" role="link">Home</a></li>
+        <li><a href="#about">About</a></li>
+    </ul>
+</nav>
+
+<main role="main">
+    <form role="form" aria-label="Signup">
+        <div>
+            <label for="email">Email</label>
+            <input id="email" type="email" role="textbox" aria-label="Email Address"/>
+        </div>
+        <div>
+            <label>
+                <input type="checkbox" role="checkbox" aria-checked="false" aria-label="Subscribe" />
+                Subscribe
+            </label>
+        </div>
+        <div>
+            <button type="submit">Submit</button>
+        </div>
+    </form>
+
+    <h2 role="heading" aria-level="2">
+        Fruits List
+    </h2>
+    <ul role="list">
+        <li role="listitem">Apple</li>
+        <li role="listitem">Banana</li>
+        <li role="listitem">Cherry</li>
+    </ul>
+
+    <img src="logo.png" alt="Company Logo" />
+    <div role="alert">This is an important alert!</div>
+    <progress role="progressbar" value="70" max="100" aria-valuenow="70">70%</progress>
+</main>
+
+<aside>
+    <button aria-labelledby="ref-1">Click Me!</button>
+    <div id="ref-1">Some_button</div>
+</aside>
+
+</body>
+</html>

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -52,7 +52,6 @@
   "devDependencies": {
     "@types/chai": "4.3.20",
     "@types/diff": "5.2.3",
-    "@types/filenamify": "2.0.2",
     "@types/mocha": "10.0.10",
     "@types/semver": "7.7.1",
     "@types/validate-npm-package-name": "4.0.2",

--- a/packages/playwright/src/screenplay/models/locators/PlaywrightLocator.ts
+++ b/packages/playwright/src/screenplay/models/locators/PlaywrightLocator.ts
@@ -1,6 +1,6 @@
 import { f, LogicError } from '@serenity-js/core';
-import type { PageElement, RootLocator, Selector } from '@serenity-js/web';
-import { ByCss, ByCssContainingText, ByDeepCss, ById, ByTagName, ByXPath, Locator } from '@serenity-js/web';
+import type { ByRoleSelectorOptions, PageElement, RootLocator, Selector } from '@serenity-js/web';
+import { ByCss, ByCssContainingText, ByDeepCss, ById, ByRole, ByTagName, ByXPath, Locator } from '@serenity-js/web';
 import type * as playwright from 'playwright-core';
 
 import { SerenitySelectorEngines } from '../../../selector-engines';
@@ -38,6 +38,10 @@ export class PlaywrightLocator extends Locator<playwright.Locator, string> {
 
         if (this.selector instanceof ById) {
             return `id=${ this.selector.value }`;
+        }
+
+        if (this.selector instanceof ByRole) {
+            return getByRoleSelector(this.selector.value, this.selector.options)
         }
 
         if (this.selector instanceof ByTagName) {
@@ -160,4 +164,59 @@ class PlaywrightParentElementLocator extends PlaywrightLocator {
     async allNativeElements(): Promise<Array<playwright.Locator>> {
         return [ await this.nativeElement() ];
     }
+}
+
+// Playwright doesn't expose the internal locator utilities, so unfortunately we need to re-implement them here.
+
+// https://github.com/microsoft/playwright/blob/release-1.55/packages/playwright-core/src/utils/isomorphic/locatorUtils.ts#L59
+function getByRoleSelector(role: string, options: ByRoleSelectorOptions = {}): string {
+    const props: string[][] = [];
+    if (options.checked !== undefined) {
+        props.push(['checked', String(options.checked)]);
+    }
+    if (options.disabled !== undefined) {
+        props.push(['disabled', String(options.disabled)]);
+    }
+    if (options.selected !== undefined) {
+        props.push(['selected', String(options.selected)]);
+    }
+    if (options.expanded !== undefined) {
+        props.push(['expanded', String(options.expanded)]);
+    }
+    if (options.includeHidden !== undefined) {
+        props.push(['include-hidden', String(options.includeHidden)]);
+    }
+    if (options.level !== undefined) {
+        props.push(['level', String(options.level)]);
+    }
+    if (options.name !== undefined) {
+        props.push(['name', escapeForAttributeSelector(options.name, !!options.exact)]);
+    }
+    if (options.pressed !== undefined) {
+        props.push(['pressed', String(options.pressed)]);
+    }
+
+    return `role=${role}${props.map(([n, v]) => `[${n}=${v}]`).join('')}`;
+}
+
+// https://github.com/microsoft/playwright/blob/release-1.55/packages/playwright-core/src/utils/isomorphic/stringUtils.ts#L92
+function escapeForAttributeSelector(value: string | RegExp, exact: boolean): string {
+    if (typeof value !== 'string') {
+        return escapeRegexForSelector(value);
+    }
+    // However, Playwright attribute selectors do not conform to CSS parsing spec,
+    // so we escape them differently.
+    return `"${value.replaceAll('\\', '\\\\').replaceAll('"', '\\"')}"${exact ? 's' : 'i'}`;
+}
+
+// https://github.com/microsoft/playwright/blob/release-1.55/packages/playwright-core/src/utils/isomorphic/stringUtils.ts#L75
+function escapeRegexForSelector(re: RegExp): string {
+    // Unicode mode does not allow "identity character escapes", so Playwright does not escape and
+    // hopes that it does not contain quotes and/or >> signs.
+    // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Regular_expressions/Character_escape
+    if (re['unicode'] || re['unicodeSets']) {
+        return String(re);
+    }
+    // Even number of backslashes followed by the quote -> insert a backslash.
+    return String(re).replaceAll(/(^|[^\\])(\\\\)*(["'`])/g, '$1$2\\$3').replaceAll('>>', '\\>\\>');
 }

--- a/packages/web/src/screenplay/models/selectors/By.ts
+++ b/packages/web/src/screenplay/models/selectors/By.ts
@@ -14,25 +14,27 @@ import { ByXPath } from './ByXPath';
  * `By` produces a [`Selector`](https://serenity-js.org/api/web/class/Selector/) used to locate a [`PageElement`](https://serenity-js.org/api/web/class/PageElement/) or [`PageElement`](https://serenity-js.org/api/web/class/PageElements/) on a web page.
  * Selectors can be defined using a static value or a [`Question`](https://serenity-js.org/api/core/class/Question/) to be resolved at runtime.
  *
- * ### Defining a selector using a static value
+ * ## Using a static value
+ *
+ * Every selector method on this class accepts a static `string` value to define a selector.
  *
  * ```typescript
  * import { PageElement, By } from '@serenity-js/web'
  *
  * class LoginForm {
  *   static usernameField = () =>
- *     PageElement.located(By.id('username'))              // locate element by its id
- *       .describedAs('username field')
+ *     PageElement.located(By.role('textbox', { name: 'Username' }))
+ *       .describedAs('username field'),
  *
  *   static passwordField = () =>
- *     PageElement.located(By.css('[data-test="password"]'))    // locate element using a CSS selector
+ *     PageElement.located(By.css('[data-test-id="password"]'))
  *       .describedAs('password field')
  * }
  * ```
  *
- * ### Defining a selector using a Question
+ * ## Defining a selector using a Question
  *
- * Each method on this class accepts an [`Answerable`](https://serenity-js.org/api/core/#Answerable) to allow for dynamic resolution of the selector.
+ * Each method on this class also accepts an [`Answerable`](https://serenity-js.org/api/core/#Answerable) to allow for dynamic resolution of the selector.
  * This can be useful when the selector is not known at the time of writing the test, or when the selector
  * needs to be calculated based on the state of the system under test.
  *
@@ -50,7 +52,7 @@ import { ByXPath } from './ByXPath';
  *
  * ```
  *
- * ### Learn more
+ * ## Learn more
  * - [Page Element Query Language](https://serenity-js.org/handbook/web-testing/page-element-query-language)
  * - [`PageElement`](https://serenity-js.org/api/web/class/PageElement/)
  * - [`PageElement`](https://serenity-js.org/api/web/class/PageElements/)
@@ -116,7 +118,7 @@ export class By {
      * Locates a [`PageElement`](https://serenity-js.org/api/web/class/PageElement/) by its [ARIA role](https://www.w3.org/TR/wai-aria-1.2/#roles),
      * [ARIA attributes](https://www.w3.org/TR/wai-aria-1.2/#aria-attributes) and [accessible name](https://w3c.github.io/accname/#dfn-accessible-name).
      *
-     * #### Example usage
+     * ### Example usage
      *
      * Given the following HTML structure:
      *
@@ -137,7 +139,7 @@ export class By {
      * const button   = PageElement.located(By.role('button', { name: 'Submit' })).describedAs('Submit button');
      * ```
      *
-     * ##### Playwright Test
+     * #### Playwright Test
      *
      * ```ts
      * import { Ensure } from '@serenity-js/assertions'
@@ -156,7 +158,7 @@ export class By {
      * })
      * ```
      *
-     * ##### WebdriverIO
+     * #### WebdriverIO
      *
      * ```ts
      * import { actorCalled } from '@serenity-js/core'

--- a/packages/web/src/screenplay/models/selectors/By.ts
+++ b/packages/web/src/screenplay/models/selectors/By.ts
@@ -14,7 +14,7 @@ import { ByXPath } from './ByXPath';
  * `By` produces a [`Selector`](https://serenity-js.org/api/web/class/Selector/) used to locate a [`PageElement`](https://serenity-js.org/api/web/class/PageElement/) or [`PageElement`](https://serenity-js.org/api/web/class/PageElements/) on a web page.
  * Selectors can be defined using a static value or a [`Question`](https://serenity-js.org/api/core/class/Question/) to be resolved at runtime.
  *
- * ## Using a static value
+ * ## Defining a selector using a string
  *
  * Every selector method on this class accepts a static `string` value to define a selector.
  *

--- a/packages/web/src/screenplay/models/selectors/By.ts
+++ b/packages/web/src/screenplay/models/selectors/By.ts
@@ -112,6 +112,75 @@ export class By {
         });
     }
 
+    /**
+     * Locates a [`PageElement`](https://serenity-js.org/api/web/class/PageElement/) by its [ARIA role](https://www.w3.org/TR/wai-aria-1.2/#roles),
+     * [ARIA attributes](https://www.w3.org/TR/wai-aria-1.2/#aria-attributes) and [accessible name](https://w3c.github.io/accname/#dfn-accessible-name).
+     *
+     * #### Example usage
+     *
+     * Given the following HTML structure:
+     *
+     * ```html
+     * <h3>Sign up</h3>
+     * <label>
+     *   <input type="checkbox" /> Subscribe
+     * </label>
+     * <br/>
+     * <button>Submit</button>
+     * ```
+     *
+     * Each element can be located by its implicit accessibility role:
+     *
+     * ```ts
+     * const heading  = PageElement.located(By.role('heading', { name: 'Sign up' })).describedAs('Sign up heading');
+     * const checkbox = PageElement.located(By.role('checkbox', { name: 'Subscribe' })).describedAs('Subscribe checkbox');
+     * const button   = PageElement.located(By.role('button', { name: 'Submit' })).describedAs('Submit button');
+     * ```
+     *
+     * And then interacted with
+     *
+     * ##### Playwright Test
+     *
+     * ```ts
+     * import { Ensure } from '@serenity-js/assertions'
+     * import { Click, PageElement, By, isVisible } from '@serenity-js/web'
+     *
+     * // ... page element definitions as above
+     *
+     * describe('ARIA role selector', () => {
+     *   it('locates an element by its accessible name', async ({ actor }) => {
+     *     await actor.attemptsTo(
+     *       Ensure.that(heading, isVisible()),
+     *       Click.on(checkbox),
+     *       Click.on(button),
+     *     )
+     *   })
+     * })
+     * ```
+     *
+     * ##### WebdriverIO
+     *
+     * ```ts
+     * import { actorCalled } from '@serenity-js/core'
+     * import { Ensure } from '@serenity-js/assertions'
+     * import { Click, PageElement, By, isVisible } from '@serenity-js/web'
+     *
+     * // ... page element definitions as above
+     *
+     * describe('ARIA role selector', () => {
+     *   it('locates an element by its accessible name', async () => {
+     *     await actorCalled('Nick').attemptsTo(
+     *       Ensure.that(heading, isVisible()),
+     *       Click.on(checkbox),
+     *       Click.on(button),
+     *     )
+     *   })
+     * })
+     * ```
+     *
+     * @param role
+     * @param options
+     */
     static role(role: ByRoleSelectorValue, options: Answerable<WithAnswerableProperties<ByRoleSelectorOptions>> = {}): Question<Promise<ByRole>> {
         const descriptionOf = (selectorOptions: Answerable<WithAnswerableProperties<ByRoleSelectorOptions>>) => {
             if (Question.isAQuestion(selectorOptions)) {

--- a/packages/web/src/screenplay/models/selectors/By.ts
+++ b/packages/web/src/screenplay/models/selectors/By.ts
@@ -137,8 +137,6 @@ export class By {
      * const button   = PageElement.located(By.role('button', { name: 'Submit' })).describedAs('Submit button');
      * ```
      *
-     * And then interacted with
-     *
      * ##### Playwright Test
      *
      * ```ts

--- a/packages/web/src/screenplay/models/selectors/By.ts
+++ b/packages/web/src/screenplay/models/selectors/By.ts
@@ -1,10 +1,12 @@
-import type { Answerable} from '@serenity-js/core';
-import { f, Question } from '@serenity-js/core';
+import type { Answerable, WithAnswerableProperties } from '@serenity-js/core';
+import { f, Question, the } from '@serenity-js/core';
 
 import { ByCss } from './ByCss';
 import { ByCssContainingText } from './ByCssContainingText';
 import { ByDeepCss } from './ByDeepCss';
 import { ById } from './ById';
+import type { ByRoleSelectorOptions, ByRoleSelectorValue } from './ByRole';
+import { ByRole } from './ByRole';
 import { ByTagName } from './ByTagName';
 import { ByXPath } from './ByXPath';
 
@@ -64,7 +66,7 @@ export class By {
      * @param selector
      */
     static css(selector: Answerable<string>): Question<Promise<ByCss>> {
-        return Question.about(f`by css (${selector})`, async actor => {
+        return Question.about(f`by css (${ selector })`, async actor => {
             const bySelector = await actor.answer(selector);
             return new ByCss(bySelector);
         });
@@ -78,7 +80,7 @@ export class By {
      * @param text
      */
     static cssContainingText(selector: Answerable<string>, text: Answerable<string>): Question<Promise<ByCssContainingText>> {
-        return Question.about(f`by css (${selector}) containing text ${ text }`, async actor => {
+        return Question.about(f`by css (${ selector }) containing text ${ text }`, async actor => {
             const bySelector = await actor.answer(selector);
             const textSelector = await actor.answer(text);
             return new ByCssContainingText(bySelector, textSelector);
@@ -92,7 +94,7 @@ export class By {
      * @param selector
      */
     static deepCss(selector: Answerable<string>): Question<Promise<ByCss>> {
-        return Question.about(f`by deep css (${selector})`, async actor => {
+        return Question.about(f`by deep css (${ selector })`, async actor => {
             const bySelector = await actor.answer(selector);
             return new ByDeepCss(bySelector);
         });
@@ -104,9 +106,33 @@ export class By {
      * @param selector
      */
     static id(selector: Answerable<string>): Question<Promise<ById>> {
-        return Question.about(f`by id (${selector})`, async actor => {
+        return Question.about(f`by id (${ selector })`, async actor => {
             const bySelector = await actor.answer(selector);
             return new ById(bySelector);
+        });
+    }
+
+    static role(role: ByRoleSelectorValue, options: Answerable<WithAnswerableProperties<ByRoleSelectorOptions>> = {}): Question<Promise<ByRole>> {
+        const descriptionOf = (selectorOptions: Answerable<WithAnswerableProperties<ByRoleSelectorOptions>>) => {
+            if (Question.isAQuestion(selectorOptions)) {
+                return the`by role ${ role } (options: ${ options  })`
+            }
+
+            if (Object.keys(selectorOptions).length === 0) {
+                return `by role "${ role }"`;
+            }
+
+            const description = [];
+            for (const [ key, value ] of Object.entries(selectorOptions)) {
+                description.push(key + f`: ${ value }`);
+            }
+
+            return `by role "${ role }" (${ description.join(', ') })`;
+        }
+
+        return Question.about(descriptionOf(options), async actor => {
+            const optionsValue = await actor.answer(Question.fromObject(options)) as ByRoleSelectorOptions;
+            return new ByRole(role, optionsValue);
         });
     }
 
@@ -116,7 +142,7 @@ export class By {
      * @param selector
      */
     static tagName(selector: Answerable<string>): Question<Promise<ByTagName>> {
-        return Question.about(f`by tag name (${selector})`, async actor => {
+        return Question.about(f`by tag name (${ selector })`, async actor => {
             const bySelector = await actor.answer(selector);
             return new ByTagName(bySelector);
         });
@@ -128,7 +154,7 @@ export class By {
      * @param selector
      */
     static xpath(selector: Answerable<string>): Question<Promise<ByXPath>> {
-        return Question.about(f`by xpath (${selector})`, async actor => {
+        return Question.about(f`by xpath (${ selector })`, async actor => {
             const bySelector = await actor.answer(selector);
             return new ByXPath(bySelector);
         });

--- a/packages/web/src/screenplay/models/selectors/ByRole.ts
+++ b/packages/web/src/screenplay/models/selectors/ByRole.ts
@@ -1,0 +1,205 @@
+import { Selector } from './Selector';
+
+export type ByRoleSelectorValue =
+    | 'alert'
+    | 'alertdialog'
+    | 'application'
+    | 'article'
+    | 'banner'
+    | 'blockquote'
+    | 'button'
+    | 'caption'
+    | 'cell'
+    | 'checkbox'
+    | 'code'
+    | 'columnheader'
+    | 'combobox'
+    | 'complementary'
+    | 'contentinfo'
+    | 'definition'
+    | 'deletion'
+    | 'dialog'
+    | 'directory'
+    | 'document'
+    | 'emphasis'
+    | 'feed'
+    | 'figure'
+    | 'form'
+    | 'generic'
+    | 'grid'
+    | 'gridcell'
+    | 'group'
+    | 'heading'
+    | 'img'
+    | 'insertion'
+    | 'link'
+    | 'list'
+    | 'listbox'
+    | 'listitem'
+    | 'log'
+    | 'main'
+    | 'marquee'
+    | 'math'
+    | 'meter'
+    | 'menu'
+    | 'menubar'
+    | 'menuitem'
+    | 'menuitemcheckbox'
+    | 'menuitemradio'
+    | 'navigation'
+    | 'none'
+    | 'note'
+    | 'option'
+    | 'paragraph'
+    | 'presentation'
+    | 'progressbar'
+    | 'radio'
+    | 'radiogroup'
+    | 'region'
+    | 'row'
+    | 'rowgroup'
+    | 'rowheader'
+    | 'scrollbar'
+    | 'search'
+    | 'searchbox'
+    | 'separator'
+    | 'slider'
+    | 'spinbutton'
+    | 'status'
+    | 'strong'
+    | 'subscript'
+    | 'superscript'
+    | 'switch'
+    | 'tab'
+    | 'table'
+    | 'tablist'
+    | 'tabpanel'
+    | 'term'
+    | 'textbox'
+    | 'time'
+    | 'timer'
+    | 'toolbar'
+    | 'tooltip'
+    | 'tree'
+    | 'treegrid'
+    | 'treeitem'
+
+export class ByRole extends Selector {
+    constructor(public readonly value: ByRoleSelectorValue, public readonly options: ByRoleSelectorOptions) {
+        super();
+    }
+}
+
+export interface ByRoleSelectorOptions {
+
+    /**
+     * An attribute that is usually set by [`aria-checked`](https://www.w3.org/TR/wai-aria-1.2/#aria-checked) or
+     * native `<input type=checkbox>` controls.
+     *
+     * :::tip Playwright only
+     * This property is supported only by Playwright.
+     * :::
+     */
+    checked?: boolean;
+
+    /**
+     * An attribute that is usually set by `aria-disabled` or `disabled`.
+     *
+     * **NOTE** Unlike most other attributes, `disabled` is inherited through the DOM hierarchy. Learn more about
+     * [`aria-disabled`](https://www.w3.org/TR/wai-aria-1.2/#aria-disabled).
+     *
+     * :::tip Playwright only
+     * This property is supported only by Playwright.
+     * :::
+     */
+    disabled?: boolean;
+
+    /**
+     * Whether [`name`](https://serenity-js.org/api/web/interface/ByRoleSelectorOptions/#name) is matched exactly:
+     * case-sensitive and whole-string.
+     *
+     * :::tip Playwright matching defaults
+     * Playwright defaults to `false` for backwards compatibility, but we recommend setting this property to `true`
+     * to avoid unintentional matches.
+     * :::
+     *
+     * :::tip Playwright and name RegExp
+     * Playwright supports using a `RegExp` to match the name.
+     * When using a `RegExp`, exact matching is not applicable and this option is ignored.
+     * Note that **exact match still trims whitespace**.
+     * :::
+     *
+     * :::tip WebdriverIO
+     * WebdriverIO always performs exact matching, so this option is ignored.
+     * :::
+     */
+    exact?: boolean;
+
+    /**
+     * An attribute that is usually set by `aria-expanded`.
+     *
+     * Learn more about [`aria-expanded`](https://www.w3.org/TR/wai-aria-1.2/#aria-expanded).
+     *
+     * :::tip Playwright only
+     * This property is supported only by Playwright.
+     * :::
+     */
+    expanded?: boolean;
+
+    /**
+     * Option that controls whether hidden elements are matched. By default, only non-hidden elements, as
+     * [defined by ARIA](https://www.w3.org/TR/wai-aria-1.2/#tree_exclusion), are matched by role selector.
+     *
+     * Learn more about [`aria-hidden`](https://www.w3.org/TR/wai-aria-1.2/#aria-hidden).
+     *
+     * :::tip Playwright only
+     * This property is supported only by Playwright.
+     * :::
+     */
+    includeHidden?: boolean;
+
+    /**
+     * A number attribute that is usually present for roles `heading`, `listitem`, `row`, `treeitem`, with default values
+     * for `<h1>-<h6>` elements.
+     *
+     * Learn more about [`aria-level`](https://www.w3.org/TR/wai-aria-1.2/#aria-level).
+     *
+     * :::tip Playwright only
+     * This property is supported only by Playwright.
+     * :::
+     */
+    level?: number;
+
+    /**
+     * Option to match the [accessible name](https://w3c.github.io/accname/#dfn-accessible-name).
+     *
+     * :::tip Playwright
+     * Only Playwright supports using a `RegExp` to match the name. When using a `string` instead, Playwright performs
+     * a **case-insensitive** match and searches for a **substring**. Use
+     * [`exact`](https://serenity-js.org/api/web/interface/ByRoleSelectorOptions/#exact) to control this behavior.
+     * :::
+     *
+     * :::tip WebdriverIO
+     * WebdriverIO does not support using `RegExp` and performs a **case-sensitive** and **exact** matching.
+     * :::
+     */
+    name?: string | RegExp;
+
+    /**
+     * An attribute that is usually set by [`aria-pressed`](https://www.w3.org/TR/wai-aria-1.2/#aria-pressed).
+     *
+     * :::tip Playwright only
+     * This property is supported only by Playwright.
+     * :::
+     */
+    pressed?: boolean;
+
+    /**
+     * An attribute that is usually set by [`aria-selected`](https://www.w3.org/TR/wai-aria-1.2/#aria-selected).
+     *
+     * :::tip Playwright only
+     * This property is supported only by Playwright.
+     * :::
+     */
+    selected?: boolean;
+}

--- a/packages/web/src/screenplay/models/selectors/index.ts
+++ b/packages/web/src/screenplay/models/selectors/index.ts
@@ -3,6 +3,7 @@ export * from './ByCss';
 export * from './ByCssContainingText';
 export * from './ByDeepCss';
 export * from './ById';
+export * from './ByRole';
 export * from './ByTagName';
 export * from './ByXPath';
 export * from './Selector';

--- a/packages/webdriverio-8/src/screenplay/models/locators/WebdriverIOLocator.ts
+++ b/packages/webdriverio-8/src/screenplay/models/locators/WebdriverIOLocator.ts
@@ -42,7 +42,7 @@ export class WebdriverIOLocator extends Locator<WebdriverIO.Element, string> {
         }
 
         if (this.selector instanceof ByRole) {
-            return this.selector.options.name
+            return this.selector.options.name && typeof this.selector.options.name === 'string'
                 ? `aria/${ this.selector.options.name }`
                 : `[role=${ this.selector.value }]`;
         }

--- a/packages/webdriverio-8/src/screenplay/models/locators/WebdriverIOLocator.ts
+++ b/packages/webdriverio-8/src/screenplay/models/locators/WebdriverIOLocator.ts
@@ -2,7 +2,7 @@ import 'webdriverio';
 
 import { f, LogicError } from '@serenity-js/core';
 import type { PageElement, RootLocator, Selector } from '@serenity-js/web';
-import { ByCss, ByCssContainingText, ByDeepCss, ById, ByTagName, ByXPath, Locator } from '@serenity-js/web';
+import { ByCss, ByCssContainingText, ByDeepCss, ById, ByRole, ByTagName, ByXPath, Locator } from '@serenity-js/web';
 
 import type { WebdriverIOErrorHandler } from '../WebdriverIOErrorHandler.js';
 import { WebdriverIOPageElement } from '../WebdriverIOPageElement.js';
@@ -39,6 +39,12 @@ export class WebdriverIOLocator extends Locator<WebdriverIO.Element, string> {
 
         if (this.selector instanceof ById) {
             return `#${ this.selector.value }`;
+        }
+
+        if (this.selector instanceof ByRole) {
+            return this.selector.options.name
+                ? `aria/${ this.selector.options.name }`
+                : `[role=${ this.selector.value }]`;
         }
 
         if (this.selector instanceof ByTagName) {

--- a/packages/webdriverio/src/screenplay/models/locators/WebdriverIOLocator.ts
+++ b/packages/webdriverio/src/screenplay/models/locators/WebdriverIOLocator.ts
@@ -42,7 +42,7 @@ export class WebdriverIOLocator extends Locator<WebdriverIO.Element, string> {
         }
 
         if (this.selector instanceof ByRole) {
-            return this.selector.options.name
+            return this.selector.options.name && typeof this.selector.options.name === 'string'
                 ? `aria/${ this.selector.options.name }`
                 : `[role=${ this.selector.value }]`;
         }

--- a/packages/webdriverio/src/screenplay/models/locators/WebdriverIOLocator.ts
+++ b/packages/webdriverio/src/screenplay/models/locators/WebdriverIOLocator.ts
@@ -2,7 +2,7 @@ import 'webdriverio';
 
 import { f, LogicError } from '@serenity-js/core';
 import type { PageElement, RootLocator, Selector } from '@serenity-js/web';
-import { ByCss, ByCssContainingText, ByDeepCss, ById, ByTagName, ByXPath, Locator } from '@serenity-js/web';
+import { ByCss, ByCssContainingText, ByDeepCss, ById, ByRole, ByTagName, ByXPath, Locator } from '@serenity-js/web';
 
 import type { WebdriverIOErrorHandler } from '../WebdriverIOErrorHandler.js';
 import { WebdriverIOPageElement } from '../WebdriverIOPageElement.js';
@@ -39,6 +39,12 @@ export class WebdriverIOLocator extends Locator<WebdriverIO.Element, string> {
 
         if (this.selector instanceof ById) {
             return `#${ this.selector.value }`;
+        }
+
+        if (this.selector instanceof ByRole) {
+            return this.selector.options.name
+                ? `aria/${ this.selector.options.name }`
+                : `[role=${ this.selector.value }]`;
         }
 
         if (this.selector instanceof ByTagName) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2485,9 +2485,6 @@ importers:
       '@types/diff':
         specifier: 5.2.3
         version: 5.2.3
-      '@types/filenamify':
-        specifier: 2.0.2
-        version: 2.0.2
       '@types/mocha':
         specifier: 10.0.10
         version: 10.0.10
@@ -4707,10 +4704,6 @@ packages:
 
   '@types/express@5.0.3':
     resolution: {integrity: sha512-wGA0NX93b19/dZC1J18tKWVIYWyyF2ZjT9vin/NRu0qzzvfVzWjs04iq2rQ3H65vCTQYlRqs3YHfY7zjdV+9Kw==}
-
-  '@types/filenamify@2.0.2':
-    resolution: {integrity: sha512-/sO8rlEFYLZGjoDCIy1BmSdo+xNQbtJIgyrElZrzALolPUhBHvY/vQVGKSw4RSkREtuAv3eb6M7mDXvhpFxYbw==}
-    deprecated: This is a stub types definition. filenamify provides its own type definitions, so you do not need this installed.
 
   '@types/formidable@1.2.8':
     resolution: {integrity: sha512-6psvrUy5VDYb+yaPJReF1WrRsz+FBwyJutK9Twz1Efa27tm07bARNIkK2B8ZPWq80dXqpKfrxTO96xrtPp+AuA==}
@@ -13498,10 +13491,6 @@ snapshots:
       '@types/body-parser': 1.19.6
       '@types/express-serve-static-core': 5.0.6
       '@types/serve-static': 1.15.7
-
-  '@types/filenamify@2.0.2':
-    dependencies:
-      filenamify: 4.3.0
 
   '@types/formidable@1.2.8':
     dependencies:


### PR DESCRIPTION
In the new selector `By.role(role, options)`:
- all the `options` are fully supported by Playwright - name can be expressed as `string` or `RegEx`, additional options for selecting elements that are `pressed`, `checked`, `disabled`, `expanded`, and so on
- only the `name` option is supported by WebdriverIO

`By.role` is not supported by Protractor.