### PR TITLE
fix(playwright): corrected handling of pages closed during the test

### DIFF
--- a/integration/webdriverio-8-cucumber/package.json
+++ b/integration/webdriverio-8-cucumber/package.json
@@ -43,7 +43,7 @@
   "devDependencies": {
     "@types/mocha": "10.0.10",
     "c8": "10.1.3",
-    "chromedriver": "140.0.4",
+    "chromedriver": "142.0.0",
     "mocha": "11.7.4",
     "mocha-multi": "1.1.7",
     "ts-node": "10.9.2",

--- a/integration/webdriverio-8-web/package.json
+++ b/integration/webdriverio-8-web/package.json
@@ -54,7 +54,7 @@
     "@wdio/local-runner": "8.42.0",
     "@wdio/spec-reporter": "8.41.0",
     "c8": "10.1.3",
-    "chromedriver": "140.0.4",
+    "chromedriver": "142.0.0",
     "ci-info": "4.3.1",
     "cross-env": "10.1.0",
     "devtools": "8.42.0",

--- a/packages/playwright/src/screenplay/models/PlaywrightBrowsingSession.ts
+++ b/packages/playwright/src/screenplay/models/PlaywrightBrowsingSession.ts
@@ -55,9 +55,13 @@ export abstract class PlaywrightBrowsingSession extends BrowsingSession<Playwrig
             this.currentPlaywrightBrowserContext = await this.createBrowserContext();
 
             this.currentPlaywrightBrowserContext.on('page', async page => {
-                this.register(
-                    new PlaywrightPage(this, page, this.extraBrowserContextOptions, CorrelationId.create())
-                );
+                const playwrightPage = new PlaywrightPage(this, page, this.extraBrowserContextOptions, CorrelationId.create());
+
+                this.register(playwrightPage);
+
+                page.on('close', _closedPage => {
+                    this.deregister(playwrightPage.id);
+                });
             });
 
             if (this.extraBrowserContextOptions?.defaultNavigationTimeout) {

--- a/packages/web/src/screenplay/models/Page.ts
+++ b/packages/web/src/screenplay/models/Page.ts
@@ -246,7 +246,7 @@ export abstract class Page<Native_Element_Type = any> implements Optional, Switc
         throw new LogicError(`Couldn't find a page which ${ expectationDescription }`);
     }
 
-    constructor(
+    protected constructor(
         protected readonly session: BrowsingSession<Page<Native_Element_Type>>,
         protected readonly rootLocator: RootLocator<Native_Element_Type>,
         protected modalDialogHandler: ModalDialogHandler,
@@ -475,7 +475,7 @@ export abstract class Page<Native_Element_Type = any> implements Optional, Switc
      * Retrieves the document title of the current top-level browsing context, equivalent to calling `document.title`.
      *
      * #### Learn more
-     * - [Mozilla Developer Network: Document title](https://developer.mozilla.org/en-US/docs/Web/API/Document/title)
+     * - [Mozilla Developer Network - Document title](https://developer.mozilla.org/en-US/docs/Web/API/Document/title)
      */
     abstract title(): Promise<string>;
 
@@ -486,6 +486,9 @@ export abstract class Page<Native_Element_Type = any> implements Optional, Switc
 
     /**
      * Retrieves the name of the current top-level browsing context.
+     *
+     * #### Learn more
+     * - [Mozilla Developer Network - Window: name property](https://developer.mozilla.org/en-US/docs/Web/API/Window/name)
      */
     abstract name(): Promise<string>;
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1980,8 +1980,8 @@ importers:
         specifier: 10.1.3
         version: 10.1.3
       chromedriver:
-        specifier: 140.0.4
-        version: 140.0.4
+        specifier: 142.0.0
+        version: 142.0.0
       mocha:
         specifier: 11.7.4
         version: 11.7.4
@@ -2129,8 +2129,8 @@ importers:
         specifier: 10.1.3
         version: 10.1.3
       chromedriver:
-        specifier: 140.0.4
-        version: 140.0.4
+        specifier: 142.0.0
+        version: 142.0.0
       ci-info:
         specifier: 4.3.1
         version: 4.3.1
@@ -2157,7 +2157,7 @@ importers:
         version: 5.9.3
       wdio-chromedriver-service:
         specifier: 8.1.1
-        version: 8.1.1(@wdio/types@8.41.0)(chromedriver@140.0.4)(webdriverio@8.42.0(devtools@8.42.0(encoding@0.1.13))(encoding@0.1.13))
+        version: 8.1.1(@wdio/types@8.41.0)(chromedriver@142.0.0)(webdriverio@8.42.0(devtools@8.42.0(encoding@0.1.13))(encoding@0.1.13))
       webdriverio:
         specifier: 8.42.0
         version: 8.42.0(devtools@8.42.0(encoding@0.1.13))(encoding@0.1.13)
@@ -5921,8 +5921,8 @@ packages:
     engines: {node: '>=12.13.0'}
     hasBin: true
 
-  chromedriver@140.0.4:
-    resolution: {integrity: sha512-/NUoxYBNkJeoNj1B5ux3KxGShITlxJctkbApgVAa3ZC8EvCLKaBclwU3/IEj5MJHnBJzqOVDxs/eTyaF9k2fOg==}
+  chromedriver@142.0.0:
+    resolution: {integrity: sha512-BlMMPFOKAOYOT23tjtAjvci57gyYcasKqd/3yGKOjGMEbFZa5kfwoNcUzwL/5ugZ932MJX1fW/j8zk5KD5mHBw==}
     engines: {node: '>=20'}
     hasBin: true
 
@@ -15474,7 +15474,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  chromedriver@140.0.4:
+  chromedriver@142.0.0:
     dependencies:
       '@testim/chrome-version': 1.1.4
       axios: 1.13.1(debug@4.4.3)
@@ -21692,7 +21692,7 @@ snapshots:
     dependencies:
       defaults: 1.0.4
 
-  wdio-chromedriver-service@8.1.1(@wdio/types@8.41.0)(chromedriver@140.0.4)(webdriverio@8.42.0(devtools@8.42.0(encoding@0.1.13))(encoding@0.1.13)):
+  wdio-chromedriver-service@8.1.1(@wdio/types@8.41.0)(chromedriver@142.0.0)(webdriverio@8.42.0(devtools@8.42.0(encoding@0.1.13))(encoding@0.1.13)):
     dependencies:
       '@wdio/logger': 8.38.0
       fs-extra: 11.3.0
@@ -21701,7 +21701,7 @@ snapshots:
       webdriverio: 8.42.0(devtools@8.42.0(encoding@0.1.13))(encoding@0.1.13)
     optionalDependencies:
       '@wdio/types': 8.41.0
-      chromedriver: 140.0.4
+      chromedriver: 142.0.0
     transitivePeerDependencies:
       - supports-color
 


### PR DESCRIPTION
Correctly de-register browser windows or tabs closed as part of the test scenario and make sure the interaction to Switch.to(window) doesn't allow switching to closed tabs.

Related tickets: closes #3054