### PR TITLE
ci(github): enabled trusted publishing

### DIFF
--- a/.github/actions/setup-lerna/action.yaml
+++ b/.github/actions/setup-lerna/action.yaml
@@ -11,9 +11,6 @@ inputs:
   git_username:
     description: 'Git username'
     required: true
-  npm_token:
-    description: 'NPM Token'
-    required: true
 
 runs:
   using: 'composite'
@@ -26,5 +23,4 @@ runs:
       git config --global user.name ${{ inputs.git_username }}
       git config --global user.password ${{ inputs.github_token }}
       git config --global push.default simple
-      npm config set //registry.npmjs.org/:_authToken=${{ inputs.npm_token }} -q
       npm whoami

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -380,7 +380,6 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           git_user_email: ${{ secrets.RELEASE_GH_EMAIL }}
           git_username: ${{ secrets.RELEASE_GH_USERNAME }}
-          npm_token: ${{ secrets.NPM_TOKEN }}
 
       - name: Download compiled libs
         uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6
@@ -395,7 +394,6 @@ jobs:
       - name: Publish artifacts
         run: pnpm lerna:publish
         env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Print versions


### PR DESCRIPTION
Serenity/JS migrates to trusted publishing to improve security of the release process and avoid using NPM tokens