### PR TITLE
test(web): fix flaky test for switching to page closed by JavaScript

### DIFF
--- a/integration/web-specs/spec/expectations/isActive.spec.ts
+++ b/integration/web-specs/spec/expectations/isActive.spec.ts
@@ -73,7 +73,7 @@ describe('isActive', function () {
                 |
                 | Expected boolean:\\s+true
                 | Received Proxy<QuestionStatement>
-                |
+                | 
                 | [A-Za-z]+PageElement {
                 |   locator: [A-Za-z]+Locator {
                 |     parent: [A-Za-z]+RootLocator { }
@@ -81,8 +81,7 @@ describe('isActive', function () {
                 |       value: 'does-not-exist'
                 |     }
                 |   }
-                | }
-                |     at .+`, 'gm')));
+                | }`, 'gm')));
 
         /** @test {isActive} */
         it('does not exist in a list of PageElements', () =>
@@ -95,9 +94,8 @@ describe('isActive', function () {
                 |
                 | Expected boolean:\\s+true
                 | Received Proxy<MetaQuestionStatement>
-                |
-                | Unanswered { }
-                |     at .+`, 'gm')));
+                | 
+                | Unanswered { }`, 'gm')));
     });
 
     /** @test {isActive} */

--- a/integration/web-specs/spec/expectations/isPresent.spec.ts
+++ b/integration/web-specs/spec/expectations/isPresent.spec.ts
@@ -44,8 +44,7 @@ describe('isPresent', function () {
             |       value: 'h2'
             |     }
             |   }
-            | }
-            |     at .+`, 'gm')));
+            | }`, 'gm')));
 
     /** @test {isPresent} */
     it('breaks the actor flow when element is not present in the DOM', () =>
@@ -66,8 +65,7 @@ describe('isPresent', function () {
             |       value: 'h2'
             |     }
             |   }
-            | }
-            |     at .+`, 'gm')));
+            | }`, 'gm')));
 
     /** @test {isPresent} */
     it(`produces an assertion error that can be serialised with ErrorSerialiser`, () =>


### PR DESCRIPTION
Add Wait.until to ensure the page is discarded before attempting to switch to it. This prevents a race condition where the browser throws TargetCloseError before Serenity/JS can detect the page is gone and throw the expected LogicError.