### PR TITLE
feat(core): differentiate between ActorEntersStage and ActorSpotlighted events

### DIFF
--- a/integration/web-specs/spec/screenplay/interactions/execute-script/ExecuteAsynchronousScript.spec.ts
+++ b/integration/web-specs/spec/screenplay/interactions/execute-script/ExecuteAsynchronousScript.spec.ts
@@ -3,9 +3,27 @@ import 'mocha';
 import { EventRecorder, expect } from '@integration/testing-tools';
 import { Ensure, equals } from '@serenity-js/assertions';
 import { actorCalled, Clock, Question, Serenity, serenity } from '@serenity-js/core';
-import { ActivityFinished, ActivityRelatedArtifactGenerated, ActivityStarts, ActorEntersStage, ArtifactGenerated, SceneFinishes, SceneStarts } from '@serenity-js/core/lib/events';
+import {
+    ActivityFinished,
+    ActivityRelatedArtifactGenerated,
+    ActivityStarts,
+    ActorEntersStage,
+    ActorSpotlighted,
+    ArtifactGenerated,
+    SceneFinishes,
+    SceneStarts
+} from '@serenity-js/core/lib/events';
 import { ExecutionSuccessful, TextData } from '@serenity-js/core/lib/model';
-import { By, ExecuteScript, LastScriptExecution, Navigate, PageElement, PageElements, Switch, Value } from '@serenity-js/web';
+import {
+    By,
+    ExecuteScript,
+    LastScriptExecution,
+    Navigate,
+    PageElement,
+    PageElements,
+    Switch,
+    Value
+} from '@serenity-js/web';
 
 import { defaultCardScenario, sceneId } from '../../../stage/crew/photographer/fixtures';
 
@@ -21,7 +39,7 @@ describe('ExecuteAsynchronousScript', function () {
             const location = activity.instantiationLocation();
 
             expect(location.path.basename()).to.equal('ExecuteAsynchronousScript.spec.ts');
-            expect(location.line).to.equal(20);
+            expect(location.line).to.equal(38);
             expect(location.column).to.equal(44);
         });
 
@@ -38,7 +56,7 @@ describe('ExecuteAsynchronousScript', function () {
             const location = activity.instantiationLocation();
 
             expect(location.path.basename()).to.equal('ExecuteAsynchronousScript.spec.ts');
-            expect(location.line).to.equal(37);
+            expect(location.line).to.equal(55);
             expect(location.column).to.equal(16);
         });
     });
@@ -275,14 +293,15 @@ describe('ExecuteAsynchronousScript', function () {
 
         const events = recorder.events;
 
-        expect(events.length).to.be.greaterThan(5);
+        expect(events.length).to.be.greaterThan(6);
         expect(events[0]).to.be.instanceOf(SceneStarts);
         expect(events[1]).to.be.instanceOf(ActorEntersStage);
-        expect(events[2]).to.be.instanceOf(ActivityStarts);
-        expect(events[3]).to.be.instanceOf(ArtifactGenerated);
-        expect(events[4]).to.be.instanceOf(ActivityFinished);
+        expect(events[2]).to.be.instanceOf(ActorSpotlighted);
+        expect(events[3]).to.be.instanceOf(ActivityStarts);
+        expect(events[4]).to.be.instanceOf(ArtifactGenerated);
+        expect(events[5]).to.be.instanceOf(ActivityFinished);
 
-        const artifactGenerated = events[3] as ActivityRelatedArtifactGenerated;
+        const artifactGenerated = events[4] as ActivityRelatedArtifactGenerated;
 
         expect(artifactGenerated.name.value).to.equal(`Script source`);
 

--- a/integration/web-specs/spec/screenplay/interactions/execute-script/ExecuteSynchronousScript.spec.ts
+++ b/integration/web-specs/spec/screenplay/interactions/execute-script/ExecuteSynchronousScript.spec.ts
@@ -8,6 +8,7 @@ import {
     ActivityRelatedArtifactGenerated,
     ActivityStarts,
     ActorEntersStage,
+    ActorSpotlighted,
     ArtifactGenerated,
     SceneFinishes,
     SceneStarts
@@ -38,7 +39,7 @@ describe('ExecuteSynchronousScript', function () {
             const location = activity.instantiationLocation();
 
             expect(location.path.basename()).to.equal('ExecuteSynchronousScript.spec.ts');
-            expect(location.line).to.equal(37);
+            expect(location.line).to.equal(38);
             expect(location.column).to.equal(44);
         });
 
@@ -52,7 +53,7 @@ describe('ExecuteSynchronousScript', function () {
             const location = activity.instantiationLocation();
 
             expect(location.path.basename()).to.equal('ExecuteSynchronousScript.spec.ts');
-            expect(location.line).to.equal(51);
+            expect(location.line).to.equal(52);
             expect(location.column).to.equal(16);
         });
     });
@@ -234,13 +235,14 @@ describe('ExecuteSynchronousScript', function () {
 
         const events = recorder.events;
 
-        expect(events.length).to.be.greaterThan(5);
+        expect(events.length).to.be.greaterThan(6);
         expect(events[1]).to.be.instanceOf(ActorEntersStage);
-        expect(events[2]).to.be.instanceOf(ActivityStarts);
-        expect(events[3]).to.be.instanceOf(ArtifactGenerated);
-        expect(events[4]).to.be.instanceOf(ActivityFinished);
+        expect(events[2]).to.be.instanceOf(ActorSpotlighted);
+        expect(events[3]).to.be.instanceOf(ActivityStarts);
+        expect(events[4]).to.be.instanceOf(ArtifactGenerated);
+        expect(events[5]).to.be.instanceOf(ActivityFinished);
 
-        const artifactGenerated = events[3] as ActivityRelatedArtifactGenerated;
+        const artifactGenerated = events[4] as ActivityRelatedArtifactGenerated;
 
         expect(artifactGenerated.name.value).to.equal(`Script source`);
 

--- a/integration/web-specs/spec/stage/crew/photographer/strategies/TakePhotosOfFailures.spec.ts
+++ b/integration/web-specs/spec/stage/crew/photographer/strategies/TakePhotosOfFailures.spec.ts
@@ -39,7 +39,7 @@ describe('Photographer', () => {
             expect(stage.theActorCalled('Betty').attemptsTo(
                 Perform.interactionThatSucceeds(),
             )).to.be.fulfilled.then(() => stage.waitForNextCue().then(() => {
-                expect(recorder.events).to.have.lengthOf(4);    // Scene starts, Actor initialised, Interaction starts and finishes
+                expect(recorder.events).to.have.lengthOf(5);    // Scene starts, Actor initialised, Actor activated, Interaction starts and finishes
             })));
 
         it('takes a photo when a problem occurs', () =>

--- a/integration/web-specs/spec/stage/crew/photographer/strategies/TakePhotosOfInteractions.errors.spec.ts
+++ b/integration/web-specs/spec/stage/crew/photographer/strategies/TakePhotosOfInteractions.errors.spec.ts
@@ -4,6 +4,7 @@ import { EventRecorder, expect } from '@integration/testing-tools';
 import { Cast, Duration } from '@serenity-js/core';
 import {
     ActorEntersStage,
+    ActorSpotlighted,
     InteractionFinished,
     InteractionStarts,
     SceneFinishes,
@@ -46,11 +47,12 @@ describe('Photographer', () => {
                 Perform.interactionThatSucceeds(1),
             )).to.be.fulfilled.then(() => stage.waitForNextCue().then(() => {
 
-                expect(recorder.events.length).to.equal(4);
+                expect(recorder.events.length).to.equal(5);
                 expect(recorder.events[0]).to.be.instanceOf(SceneStarts);
                 expect(recorder.events[1]).to.be.instanceOf(ActorEntersStage);
-                expect(recorder.events[2]).to.be.instanceOf(InteractionStarts);
-                expect(recorder.events[3]).to.be.instanceOf(InteractionFinished);
+                expect(recorder.events[2]).to.be.instanceOf(ActorSpotlighted);
+                expect(recorder.events[3]).to.be.instanceOf(InteractionStarts);
+                expect(recorder.events[4]).to.be.instanceOf(InteractionFinished);
 
                 // no artifacts generated for an actor with no ability to BrowseTheWeb
             })));

--- a/packages/core/spec/Serenity.spec.ts
+++ b/packages/core/spec/Serenity.spec.ts
@@ -4,7 +4,7 @@ import { describe, it } from 'mocha';
 import { ConfigurationError } from '../src';
 import type { OutputStream } from '../src/adapter';
 import type { DomainEvent} from '../src/events';
-import { ActivityFinished, ActivityStarts, ActorEntersStage, TestRunnerDetected } from '../src/events';
+import { ActivityFinished, ActivityStarts, ActorEntersStage, ActorSpotlighted, TestRunnerDetected } from '../src/events';
 import { CorrelationId, Name } from '../src/model';
 import type { Actor } from '../src/screenplay';
 import { Clock, Interaction } from '../src/screenplay';
@@ -167,8 +167,8 @@ describe('Serenity', () => {
             ],
         });
 
-        // backstage actor is retrieved within the scenario scope
-        expect(listener.events[1]).to.be.instanceOf(ActorEntersStage);
+        // actor becomes active (spotlight shifts to them)
+        expect(listener.events[1]).to.be.instanceOf(ActorSpotlighted);
 
         const activityStarts = listener.events[2] as ActivityStarts;
 

--- a/packages/core/spec/events/actor/ActorSpotlighted.spec.ts
+++ b/packages/core/spec/events/actor/ActorSpotlighted.spec.ts
@@ -1,0 +1,57 @@
+import { describe, it } from 'mocha';
+
+import { ActorSpotlighted } from '../../../src/events';
+import { CorrelationId } from '../../../src/model';
+import { Timestamp } from '../../../src/screenplay';
+import { expect } from '../../expect';
+
+describe('ActorSpotlighted', () => {
+
+    const sceneId = new CorrelationId('example-scene-id');
+    const actor = { name: 'Alice', abilities: [] };
+
+    describe('constructor', () => {
+
+        it('sets sceneId, actor, and timestamp correctly', () => {
+            const timestamp = new Timestamp(new Date('2024-01-15T10:30:00Z'));
+
+            const event = new ActorSpotlighted(sceneId, actor, timestamp);
+
+            expect(event.sceneId).to.equal(sceneId);
+            expect(event.actor).to.deep.equal(actor);
+            expect(event.timestamp).to.equal(timestamp);
+        });
+    });
+
+    describe('fromJSON', () => {
+
+        it('deserializes the event correctly', () => {
+            const timestamp = new Timestamp(new Date('2024-01-15T10:30:00Z'));
+
+            const json = {
+                sceneId: 'example-scene-id',
+                actor: { name: 'Alice', abilities: [] },
+                timestamp: timestamp.toJSON(),
+            };
+
+            const event = ActorSpotlighted.fromJSON(json);
+
+            expect(event.sceneId.value).to.equal('example-scene-id');
+            expect(event.actor).to.deep.equal({ name: 'Alice', abilities: [] });
+            expect(event.timestamp).to.equal(timestamp);
+        });
+    });
+
+    describe('validation', () => {
+
+        it('rejects undefined sceneId', () => {
+            expect(() => new ActorSpotlighted(undefined, actor))
+                .to.throw(Error, 'sceneId should be defined');
+        });
+
+        it('rejects undefined actor', () => {
+            expect(() => new ActorSpotlighted(sceneId, undefined))
+                .to.throw(Error, 'actor should be defined');
+        });
+    });
+});

--- a/packages/core/src/events/actor/ActorEntersStage.ts
+++ b/packages/core/src/events/actor/ActorEntersStage.ts
@@ -6,8 +6,14 @@ import { type SerialisedActor, Timestamp } from '../../screenplay';
 import { DomainEvent } from '../DomainEvent';
 
 /**
- * Emitted when an [`Actor`](https://serenity-js.org/api/core/class/Actor/) is activated
+ * Emitted when an [`Actor`](https://serenity-js.org/api/core/class/Actor/) is first instantiated
  * as the result of invoking [`actorCalled`](https://serenity-js.org/api/core/function/actorCalled/).
+ *
+ * This event is emitted only once per actor, when they are first created.
+ * Subsequent retrievals of the same actor do not emit this event.
+ *
+ * To track when the spotlight shifts to a different actor, listen for
+ * [`ActorSpotlighted`](https://serenity-js.org/api/core-events/class/ActorSpotlighted/) instead.
  *
  * @group Events
  */

--- a/packages/core/src/events/actor/ActorSpotlighted.ts
+++ b/packages/core/src/events/actor/ActorSpotlighted.ts
@@ -1,0 +1,40 @@
+import type { JSONObject } from 'tiny-types';
+import { ensure, isDefined } from 'tiny-types';
+
+import { CorrelationId } from '../../model';
+import type { SerialisedActor } from '../../screenplay';
+import { Timestamp } from '../../screenplay';
+import { DomainEvent } from '../DomainEvent';
+
+/**
+ * Emitted when an [`Actor`](https://serenity-js.org/api/core/class/Actor/) becomes
+ * the active actor (moves into the spotlight) as the result of invoking
+ * [`actorCalled`](https://serenity-js.org/api/core/function/actorCalled/).
+ *
+ * This event is emitted only when the spotlight shifts to a different actor.
+ * Consecutive retrievals of the same actor do not emit additional events.
+ *
+ * To detect when an actor is instantiated for the first time, listen for
+ * [`ActorEntersStage`](https://serenity-js.org/api/core-events/class/ActorEntersStage/).
+ *
+ * @group Events
+ */
+export class ActorSpotlighted extends DomainEvent {
+    public static fromJSON(o: JSONObject): ActorSpotlighted {
+        return new ActorSpotlighted(
+            CorrelationId.fromJSON(o.sceneId as string),
+            o.actor as unknown as SerialisedActor,
+            Timestamp.fromJSON(o.timestamp as string),
+        );
+    }
+
+    constructor(
+        public readonly sceneId: CorrelationId,
+        public readonly actor: SerialisedActor,
+        timestamp?: Timestamp,
+    ) {
+        super(timestamp);
+        ensure('sceneId', sceneId, isDefined());
+        ensure('actor', actor, isDefined());
+    }
+}

--- a/packages/core/src/events/actor/index.ts
+++ b/packages/core/src/events/actor/index.ts
@@ -1,4 +1,5 @@
 export * from './ActorEntersStage';
+export * from './ActorSpotlighted';
 export * from './ActorStageExitAttempted';
 export * from './ActorStageExitCompleted';
 export * from './ActorStageExitFailed';

--- a/packages/rest/spec/screenplay/interactions/Send.spec.ts
+++ b/packages/rest/spec/screenplay/interactions/Send.spec.ts
@@ -6,11 +6,19 @@ import {
     ActivityRelatedArtifactGenerated,
     ActivityStarts,
     ActorEntersStage,
+    ActorSpotlighted,
     SceneFinishes,
     SceneStarts
 } from '@serenity-js/core/lib/events';
 import { FileSystemLocation, Path } from '@serenity-js/core/lib/io';
-import { Category, CorrelationId, ExecutionSuccessful, HTTPRequestResponse, Name, ScenarioDetails } from '@serenity-js/core/lib/model';
+import {
+    Category,
+    CorrelationId,
+    ExecutionSuccessful,
+    HTTPRequestResponse,
+    Name,
+    ScenarioDetails
+} from '@serenity-js/core/lib/model';
 import axios from 'axios';
 import MockAdapter from 'axios-mock-adapter';
 import { afterEach, beforeEach, describe, it } from 'mocha';
@@ -42,7 +50,7 @@ describe('Send', () => {
         const location = activity.instantiationLocation();
 
         expect(location.path.basename()).to.equal('Send.spec.ts');
-        expect(location.line).to.equal(41);
+        expect(location.line).to.equal(49);
         expect(location.column).to.equal(31);
     });
 
@@ -119,11 +127,12 @@ describe('Send', () => {
         expect(events).to.have.length.greaterThan(5);
         expect(events[ 0 ]).to.be.instanceOf(SceneStarts);
         expect(events[ 1 ]).to.be.instanceOf(ActorEntersStage);
-        expect(events[ 2 ]).to.be.instanceOf(ActivityStarts);
-        expect(events[ 3 ]).to.be.instanceOf(ActivityRelatedArtifactGenerated);
-        expect(events[ 4 ]).to.be.instanceOf(ActivityFinished);
+        expect(events[ 2 ]).to.be.instanceOf(ActorSpotlighted);
+        expect(events[ 3 ]).to.be.instanceOf(ActivityStarts);
+        expect(events[ 4 ]).to.be.instanceOf(ActivityRelatedArtifactGenerated);
+        expect(events[ 5 ]).to.be.instanceOf(ActivityFinished);
 
-        const artifactGenerated = events[ 3 ] as ActivityRelatedArtifactGenerated;
+        const artifactGenerated = events[ 4 ] as ActivityRelatedArtifactGenerated;
 
         expect(artifactGenerated.name.value).to.equal(`GET https://myapp.com/api/products/2`);
         expect(artifactGenerated.artifact.equals(HTTPRequestResponse.fromJSON({

--- a/packages/serenity-bdd/src/stage/crew/serenity-bdd-reporter/processors/EventQueueProcessor.ts
+++ b/packages/serenity-bdd/src/stage/crew/serenity-bdd-reporter/processors/EventQueueProcessor.ts
@@ -2,7 +2,9 @@ import type { DomainEventQueue } from '@serenity-js/core';
 import type {
     ActivityRelatedArtifactArchived,
     ActivityRelatedArtifactGenerated,
-    ActorEntersStage, ActorStageExitStarts,
+    ActorEntersStage,
+    ActorSpotlighted,
+    ActorStageExitStarts,
     BusinessRuleDetected,
     FeatureNarrativeDetected,
     SceneBackgroundDetected,
@@ -42,6 +44,12 @@ export abstract class EventQueueProcessor {
 
     protected onActorEntersStage<Context extends SerenityBDDReportContext>(report: Context) {
         return (event: ActorEntersStage): Context =>
+            report
+                .with(actorDetailsOf(event.actor, this.reporterConfig));
+    }
+
+    protected onActorSpotlighted<Context extends SerenityBDDReportContext>(report: Context) {
+        return (event: ActorSpotlighted): Context =>
             report
                 .with(actorDetailsOf(event.actor, this.reporterConfig));
     }

--- a/packages/serenity-bdd/src/stage/crew/serenity-bdd-reporter/processors/scene-sequence/SceneSequenceEventQueueProcessor.ts
+++ b/packages/serenity-bdd/src/stage/crew/serenity-bdd-reporter/processors/scene-sequence/SceneSequenceEventQueueProcessor.ts
@@ -6,6 +6,7 @@ import {
     ActivityRelatedArtifactGenerated,
     ActivityStarts,
     ActorEntersStage,
+    ActorSpotlighted,
     ActorStageExitStarts,
     BusinessRuleDetected,
     FeatureNarrativeDetected,
@@ -59,6 +60,7 @@ export class SceneSequenceEventQueueProcessor extends EventQueueProcessor {
                 .when(RetryableSceneDetected,           this.onRetryableSceneDetected(context))
                 .when(SceneStarts,                      this.onSceneStarts(context))
                 .when(ActorEntersStage,                 this.onActorEntersStage(context))
+                .when(ActorSpotlighted,                 this.onActorSpotlighted(context))
                 .when(ActorStageExitStarts,             this.onActorStageExitStarts(context))
                 .when(SceneTemplateDetected,            this.onSceneTemplateDetected(context))
                 .when(SceneParametersDetected,          this.onSceneParametersDetected(context))

--- a/packages/serenity-bdd/src/stage/crew/serenity-bdd-reporter/processors/single-scene/SingleSceneEventQueueProcessor.ts
+++ b/packages/serenity-bdd/src/stage/crew/serenity-bdd-reporter/processors/single-scene/SingleSceneEventQueueProcessor.ts
@@ -6,6 +6,7 @@ import {
     ActivityRelatedArtifactGenerated,
     ActivityStarts,
     ActorEntersStage,
+    ActorSpotlighted,
     ActorStageExitStarts,
     BusinessRuleDetected,
     FeatureNarrativeDetected,
@@ -47,6 +48,7 @@ export class SingleSceneEventQueueProcessor extends EventQueueProcessor {
             match<DomainEvent, SingleSceneReportContext>(event)
                 .when(SceneStarts,                      this.onSceneStarts(context))
                 .when(ActorEntersStage,                 this.onActorEntersStage(context))
+                .when(ActorSpotlighted,                 this.onActorSpotlighted(context))
                 .when(ActorStageExitStarts,             this.onActorStageExitStarts(context))
                 .when(FeatureNarrativeDetected,         this.onFeatureNarrativeDetected(context))
                 .when(SceneBackgroundDetected,          this.onSceneBackgroundDetected(context))


### PR DESCRIPTION
Introduces a new `ActorSpotlighted` event to track when the spotlight shifts between actors, while keeping `ActorEntersStage` to indicate when an actor is first instantiated.
Previously, `ActorEntersStage` was emitted every time an actor was retrieved, making it difficult for custom reporters to distinguish between new actors and actors being accessed again.

With this change:
- `ActorEntersStage` is emitted only once per actor, when they are first instantiated
- `ActorSpotlighted` is emitted when the active actor changes (spotlight shifts to a different actor)
- Consecutive retrievals of the same actor emit neither event

Closes #2855