### PR TITLE
fix(playwright): aligned package.json exports to use conditional import/require types

### DIFF
--- a/integration/playwright-test/examples/screenplay/native-page.spec.ts
+++ b/integration/playwright-test/examples/screenplay/native-page.spec.ts
@@ -29,7 +29,7 @@ describe('Playwright Test integration', () => {
             const localServerUrl = await actor.answer(LocalServer.url());
             const expectedLocalServerUrl = localServerUrl + '/';
 
-            expect(await page.url()).toEqual(expectedLocalServerUrl);
+            expect(page.url()).toEqual(expectedLocalServerUrl);
         });
 
         it('allows for interactions with the page object to change the state of the page associated with the actor', async ({ actor, page }) => {

--- a/packages/playwright-test/package.json
+++ b/packages/playwright-test/package.json
@@ -22,39 +22,74 @@
   "module": "./esm/index.js",
   "exports": {
     ".": {
-      "types": "./esm/index.d.ts",
-      "import": "./esm/index.js",
-      "require": "./lib/index.js"
+      "import": {
+        "types": "./esm/index.d.ts",
+        "default": "./esm/index.js"
+      },
+      "require": {
+        "types": "./lib/index.d.ts",
+        "default": "./lib/index.js"
+      }
     },
     "./events": {
-      "types": "./lib/events/index.d.ts",
-      "import": "./esm/events/index.js",
-      "require": "./lib/events/index.js"
+      "import": {
+        "types": "./esm/events/index.d.ts",
+        "default": "./esm/events/index.js"
+      },
+      "require": {
+        "types": "./lib/events/index.d.ts",
+        "default": "./lib/events/index.js"
+      }
     },
     "./reporter": {
-      "types": "./lib/reporter/index.d.ts",
-      "import": "./esm/reporter/index.js",
-      "require": "./lib/reporter/index.js"
+      "import": {
+        "types": "./esm/reporter/index.d.ts",
+        "default": "./esm/reporter/index.js"
+      },
+      "require": {
+        "types": "./lib/reporter/index.d.ts",
+        "default": "./lib/reporter/index.js"
+      }
     },
     "./api": {
-      "types": "./lib/api/index.d.ts",
-      "import": "./esm/api/index.js",
-      "require": "./lib/api/index.js"
+      "import": {
+        "types": "./esm/api/index.d.ts",
+        "default": "./esm/api/index.js"
+      },
+      "require": {
+        "types": "./lib/api/index.d.ts",
+        "default": "./lib/api/index.js"
+      }
     },
     "./lib/events": {
-      "types": "./lib/events/index.d.ts",
-      "import": "./esm/events/index.js",
-      "require": "./lib/events/index.js"
+      "import": {
+        "types": "./esm/events/index.d.ts",
+        "default": "./esm/events/index.js"
+      },
+      "require": {
+        "types": "./lib/events/index.d.ts",
+        "default": "./lib/events/index.js"
+      }
     },
     "./lib/reporter": {
-      "types": "./lib/reporter/index.d.ts",
-      "import": "./esm/reporter/index.js",
-      "require": "./lib/reporter/index.js"
+      "import": {
+        "types": "./esm/reporter/index.d.ts",
+        "default": "./esm/reporter/index.js"
+      },
+      "require": {
+        "types": "./lib/reporter/index.d.ts",
+        "default": "./lib/reporter/index.js"
+      }
     },
     "./lib/api": {
-      "types": "./lib/api/index.d.ts",
-      "import": "./esm/api/index.js",
-      "require": "./lib/api/index.js"
+      "import": {
+        "types": "./esm/api/index.d.ts",
+        "default": "./esm/api/index.js"
+      },
+      "require": {
+        "types": "./lib/api/index.d.ts",
+        "default": "./lib/api/index.js"
+      }
     },
     "./lib/*.js": "./lib/*.js",
     "./lib/*": "./lib/*",

--- a/packages/playwright/package.json
+++ b/packages/playwright/package.json
@@ -22,9 +22,14 @@
   "module": "./esm/index.js",
   "exports": {
     ".": {
-      "types": "./esm/index.d.ts",
-      "import": "./esm/index.js",
-      "require": "./lib/index.js"
+      "import": {
+        "types": "./esm/index.d.ts",
+        "default": "./esm/index.js"
+      },
+      "require": {
+        "types": "./lib/index.d.ts",
+        "default": "./lib/index.js"
+      }
     },
     "./lib/*": "./lib/*",
     "./esm/*": "./esm/*",

--- a/packages/rest/package.json
+++ b/packages/rest/package.json
@@ -22,9 +22,14 @@
   "module": "./esm/index.js",
   "exports": {
     ".": {
-      "types": "./lib/index.d.ts",
-      "import": "./esm/index.js",
-      "require": "./lib/index.js"
+      "import": {
+        "types": "./esm/index.d.ts",
+        "default": "./esm/index.js"
+      },
+      "require": {
+        "types": "./lib/index.d.ts",
+        "default": "./lib/index.js"
+      }
     },
     "./lib/*.js": "./lib/*.js",
     "./lib/*": "./lib/*",

--- a/packages/webdriverio-8/package.json
+++ b/packages/webdriverio-8/package.json
@@ -22,9 +22,14 @@
   "module": "./esm/index.js",
   "exports": {
     ".": {
-      "types": "./esm/index.d.ts",
-      "import": "./esm/index.js",
-      "require": "./lib/index.js"
+      "import": {
+        "types": "./esm/index.d.ts",
+        "default": "./esm/index.js"
+      },
+      "require": {
+        "types": "./lib/index.d.ts",
+        "default": "./lib/index.js"
+      }
     },
     "./package.json": "./package.json"
   },

--- a/packages/webdriverio/package.json
+++ b/packages/webdriverio/package.json
@@ -22,9 +22,14 @@
   "module": "./esm/index.js",
   "exports": {
     ".": {
-      "types": "./esm/index.d.ts",
-      "import": "./esm/index.js",
-      "require": "./lib/index.js"
+      "import": {
+        "types": "./esm/index.d.ts",
+        "default": "./esm/index.js"
+      },
+      "require": {
+        "types": "./lib/index.d.ts",
+        "default": "./lib/index.js"
+      }
     },
     "./package.json": "./package.json"
   },


### PR DESCRIPTION


Normalize exports across packages to prevent TypeScript from resolving mixed ESM/CJS type graphs. Previously, a single top-level "types" field could not satisfy both import and require consumers, leading to incompatible private field declarations (e.g., "Interaction is not an Activity").

Now each export branch declares its own types:
- import.types → ./esm/...d.ts
- require.types → ./lib/...d.ts

This ensures CJS consumers get CJS declarations and ESM consumers get ESM declarations, keeping the type graph unified per resolution mode.

Updated packages:
- playwright
- playwright-test (root + subpaths: ./events, ./reporter, ./api, ./lib/*)
- rest
- webdriverio
- webdriverio-8

Resolves type errors in integration tests (e.g., native-page.spec.ts) where mixed type imports caused private field incompatibilities