### PR TITLE
feat(core): silent and hidden activities for cleaner reports

### DIFF
--- a/packages/core/spec/screenplay/questions/Check.spec.ts
+++ b/packages/core/spec/screenplay/questions/Check.spec.ts
@@ -3,7 +3,7 @@ import { beforeEach, describe, it } from 'mocha';
 import * as sinon from 'sinon';
 
 import type { Actor} from '../../../src';
-import { actorCalled, Check, Interaction } from '../../../src';
+import { actorCalled, Check, Interaction, isHidden } from '../../../src';
 import { expect } from '../../expect';
 import { isIdenticalTo } from '../../isIdenticalTo';
 
@@ -115,6 +115,10 @@ describe('Check', () => {
                     name: 'Jan',
                 },
             })).andIfSo().toString()).to.equal(`#actor checks whether {"person":{"name":"Jan"}} does have value identical to {"person":{"name":"Jan"}}`);
+        });
+
+        it('is hidden, so the check itself is omitted from the report while the activities it performs are still reported', () => {
+            expect(isHidden(Check.whether(4, isIdenticalTo(4)).andIfSo())).to.equal(true);
         });
     })
 });

--- a/packages/core/spec/screenplay/reporting/reporting-markers.spec.ts
+++ b/packages/core/spec/screenplay/reporting/reporting-markers.spec.ts
@@ -1,0 +1,39 @@
+import { describe, it } from 'mocha';
+
+import { isHidden, isSilent } from '../../../src';
+import { expect } from '../../expect';
+
+describe('Reporting markers', () => {
+
+    describe('isHidden', () => {
+
+        it('is true when the activity declares itself as hidden', () => {
+            expect(isHidden({ isHidden: () => true })).to.equal(true);
+        });
+
+        it('is false when the activity declares itself as not hidden', () => {
+            expect(isHidden({ isHidden: () => false })).to.equal(false);
+        });
+
+        it('is false when the activity does not implement IsHidden', () => {
+            expect(isHidden({})).to.equal(false);
+            expect(isHidden(undefined)).to.equal(false);
+        });
+    });
+
+    describe('isSilent', () => {
+
+        it('is true when the activity declares itself as silent', () => {
+            expect(isSilent({ isSilent: () => true })).to.equal(true);
+        });
+
+        it('is false when the activity declares itself as not silent', () => {
+            expect(isSilent({ isSilent: () => false })).to.equal(false);
+        });
+
+        it('is false when the activity does not implement IsSilent', () => {
+            expect(isSilent({})).to.equal(false);
+            expect(isSilent(undefined)).to.equal(false);
+        });
+    });
+});

--- a/packages/core/src/screenplay/abilities/PerformActivities.ts
+++ b/packages/core/src/screenplay/abilities/PerformActivities.ts
@@ -18,6 +18,7 @@ import type { PerformsActivities } from '../activities/PerformsActivities.js';
 import type { Activity } from '../Activity.js';
 import { Interaction } from '../Interaction.js';
 import type { AnswersQuestions } from '../questions/index.js';
+import { isHidden, isSilent } from '../reporting/index.js';
 import { Ability } from './Ability.js';
 import type { UsesAbilities } from './UsesAbilities.js';
 
@@ -31,6 +32,13 @@ import type { UsesAbilities } from './UsesAbilities.js';
  * @group Abilities
  */
 export class PerformActivities extends Ability {
+
+    /**
+     * Depth of the currently executing {@apilink IsSilent} activity subtree.
+     * While greater than zero, no activities are reported.
+     */
+    #silentActivityDepth = 0;
+
     constructor(
         protected readonly actor: AnswersQuestions & UsesAbilities & PerformsActivities & { name: string },
         protected readonly stage: EmitsDomainEvents,
@@ -47,35 +55,51 @@ export class PerformActivities extends Ability {
             ? [ InteractionStarts, InteractionFinished ]
             : [ TaskStarts, TaskFinished ];
 
+        const silent   = isSilent(activity);
+        const reported = ! isHidden(activity) && ! silent && this.#silentActivityDepth === 0;
+
+        if (silent) {
+            this.#silentActivityDepth++;
+        }
+
         try {
-            this.stage.announce(
-                new activityStarts(
-                    sceneId,
-                    activityId,
-                    details,
-                    this.stage.currentTime()
-                )
-            );
+            if (reported) {
+                this.stage.announce(
+                    new activityStarts(
+                        sceneId,
+                        activityId,
+                        details,
+                        this.stage.currentTime()
+                    )
+                );
+            }
 
             await activity.performAs(this.actor);
 
             const name = await activity.describedBy(this.actor);
 
-            this.stage.announce(
-                new activityFinished(
-                    sceneId,
-                    activityId,
-                    this.detailsOf(name, activity.instantiationLocation()),
-                    new ExecutionSuccessful(),
-                    this.stage.currentTime()
-                )
-            );
+            if (reported) {
+                this.stage.announce(
+                    new activityFinished(
+                        sceneId,
+                        activityId,
+                        this.detailsOf(name, activity.instantiationLocation()),
+                        new ExecutionSuccessful(),
+                        this.stage.currentTime()
+                    )
+                );
+            }
         }
         catch (error) {
-            this.stage.announce(new activityFinished(sceneId, activityId, details, this.outcomeFor(error), this.stage.currentTime()));
+            if (reported) {
+                this.stage.announce(new activityFinished(sceneId, activityId, details, this.outcomeFor(error), this.stage.currentTime()));
+            }
             throw error;
         }
         finally {
+            if (silent) {
+                this.#silentActivityDepth--;
+            }
             await this.stage.waitForNextCue();
         }
     }

--- a/packages/core/src/screenplay/index.ts
+++ b/packages/core/src/screenplay/index.ts
@@ -12,6 +12,7 @@ export * from './Optional.js';
 export * from './Question.js';
 export * from './questions/index.js';
 export * from './RecursivelyAnswered.js';
+export * from './reporting/index.js';
 export * from './SerialisedActor.js';
 export * from './Task.js';
 export * from './time/index.js';

--- a/packages/core/src/screenplay/questions/Check.ts
+++ b/packages/core/src/screenplay/questions/Check.ts
@@ -3,6 +3,7 @@ import type { PerformsActivities } from '../activities/index.js';
 import type { Activity } from '../Activity.js';
 import type { Answerable } from '../Answerable.js';
 import type { AnswersQuestions } from '../questions/index.js';
+import type { IsHidden } from '../reporting/index.js';
 import { Task } from '../Task.js';
 import type { Expectation } from './Expectation.js';
 import { ExpectationMet } from './expectations/index.js';
@@ -46,7 +47,7 @@ import { ExpectationMet } from './expectations/index.js';
  *
  * @group Activities
  */
-export class Check<Actual> extends Task {
+export class Check<Actual> extends Task implements IsHidden {
 
     static whether<Actual_Type>(actual: Answerable<Actual_Type>, expectation: Expectation<Actual_Type>): { andIfSo: (...activities: Activity[]) => Check<Actual_Type> } {
         return {
@@ -81,5 +82,15 @@ export class Check<Actual> extends Task {
         return outcome instanceof ExpectationMet
             ? actor.attemptsTo(...this.activities)
             : actor.attemptsTo(...this.alternativeActivities);
+    }
+
+    /**
+     * A [`Check`](https://serenity-js.org/api/core/class/Check/) is a flow-control statement, so its own step
+     * is omitted from the report; the activities it decides to perform are still reported.
+     *
+     * This mirrors Serenity BDD (Java), where `ConditionalPerformable` implements `IsHidden`.
+     */
+    isHidden(): boolean {
+        return true;
     }
 }

--- a/packages/core/src/screenplay/reporting/IsHidden.ts
+++ b/packages/core/src/screenplay/reporting/IsHidden.ts
@@ -1,0 +1,27 @@
+/**
+ * An [`Activity`](https://serenity-js.org/api/core/class/Activity/) implementing `IsHidden` has its own step
+ * omitted from the report, while any nested activities it performs are still reported.
+ *
+ * For example, [`Check`](https://serenity-js.org/api/core/class/Check/) implements `IsHidden` so that the conditional
+ * check itself doesn't clutter the report, while the activities it decides to perform still do.
+ *
+ * Inspired by Serenity BDD's `net.serenitybdd.markers.IsHidden`.
+ *
+ * @group Screenplay Pattern
+ */
+export interface IsHidden {
+    /**
+     * Returns `true` when this activity's own step should be omitted from the report.
+     * Nested activities are still reported.
+     */
+    isHidden(): boolean;
+}
+
+/**
+ * Returns `true` when the given `activity` declares itself as {@apilink IsHidden}.
+ */
+export function isHidden(activity: unknown): boolean {
+    return Boolean(activity)
+        && typeof (activity as IsHidden).isHidden === 'function'
+        && (activity as IsHidden).isHidden();
+}

--- a/packages/core/src/screenplay/reporting/IsSilent.ts
+++ b/packages/core/src/screenplay/reporting/IsSilent.ts
@@ -1,0 +1,26 @@
+/**
+ * An [`Activity`](https://serenity-js.org/api/core/class/Activity/) implementing `IsSilent` has its own step,
+ * **and every nested activity it performs**, omitted from the report. Use it for setup or teardown activities
+ * whose reporting would only add noise.
+ *
+ * The `isSilent()` method allows silence to be decided dynamically.
+ *
+ * Inspired by Serenity BDD's `net.serenitybdd.markers.IsSilent` and its `CanBeSilent` companion.
+ *
+ * @group Screenplay Pattern
+ */
+export interface IsSilent {
+    /**
+     * Returns `true` when this activity's own step, and everything nested under it, should be omitted from the report.
+     */
+    isSilent(): boolean;
+}
+
+/**
+ * Returns `true` when the given `activity` declares itself as {@apilink IsSilent}.
+ */
+export function isSilent(activity: unknown): boolean {
+    return Boolean(activity)
+        && typeof (activity as IsSilent).isSilent === 'function'
+        && (activity as IsSilent).isSilent();
+}

--- a/packages/core/src/screenplay/reporting/index.ts
+++ b/packages/core/src/screenplay/reporting/index.ts
@@ -1,0 +1,2 @@
+export * from './IsHidden.js';
+export * from './IsSilent.js';


### PR DESCRIPTION
## What this adds

Ports the reporting markers from Serenity BDD (Java) so that control-flow and setup activities can opt out of reporting:

- **`IsHidden`**: an activity's own step is omitted from the report, while the activities it performs are still reported. `Check` now implements `IsHidden` (matching Java's `ConditionalPerformable`), so a conditional no longer narrates its own "checks whether ..." step; only the branch it decides to perform is reported.
- **`IsSilent`**: an activity's own step, and everything nested under it, are omitted from the report. Useful for setup or teardown activities whose reporting would only add noise. The `isSilent()` method lets silence be decided dynamically, mirroring Java's `CanBeSilent`.

`PerformActivities` honours both markers at the single point where activity domain events are announced, so the behaviour is consistent across every reporter (console, Serenity BDD, and any custom crew).

## Motivation

Reports for scenarios that repeatedly dismiss cookie banners, or run instrumented setup/teardown, fill up with steps that add no value. `Check` in particular narrates a "checks whether ..." line for every conditional, even when the branch does nothing. In Serenity BDD (Java) `ConditionalPerformable` is `IsHidden`, so this brings the two products back in line.

## Behaviour note

`Check` is hidden by default in this change, matching Java's `ConditionalPerformable`. That removes the conditional's own line from existing reports, leaving only the branch it performs. If you would rather keep current `Check` output and make hiding opt-in, I am happy to adjust so the markers ship without changing `Check`'s default.

## Tests

- `packages/core/spec/screenplay/reporting/reporting-markers.spec.ts`: the `isHidden` / `isSilent` guards.
- `packages/core/spec/screenplay/questions/Check.spec.ts`: asserts `Check` is hidden.

## Related discussion

- serenity-bdd/serenity-core#669: the Serenity BDD (Java) capability this mirrors.
- serenity-js/serenity-js#161 and serenity-js/serenity-js#365: earlier discussions about hiding steps and silent operations.
- serenity-js/serenity-js#155 and serenity-js/serenity-js#159: the original flow-control / `ConditionalPerformable` work that became `Check`.
