### PR TITLE
feat(playwright-test): opt-in live domain events streamed from workers to the reporter crew

### DIFF
--- a/integration/playwright-test/examples/live-events/long-running-scenario.spec.ts
+++ b/integration/playwright-test/examples/live-events/long-running-scenario.spec.ts
@@ -1,0 +1,13 @@
+import { Duration, Log, Wait } from '@serenity-js/core';
+import { describe, it } from '@serenity-js/playwright-test';
+
+describe('Live events', () => {
+
+    it('streams domain events while the scenario is still running', async ({ actorCalled }) => {
+        await actorCalled('Alice').attemptsTo(
+            Log.the('first interaction'),
+            Wait.for(Duration.ofSeconds(2)),
+            Log.the('second interaction'),
+        );
+    });
+});

--- a/integration/playwright-test/playwright-live-events.config.ts
+++ b/integration/playwright-test/playwright-live-events.config.ts
@@ -1,0 +1,48 @@
+import path from 'node:path';
+
+import { defineConfig, devices } from '@playwright/test';
+import { SerenityFixtures, SerenityWorkerFixtures } from '@serenity-js/playwright-test';
+
+import { LiveEventsRecorder } from './src/LiveEventsRecorder';
+
+export default defineConfig<SerenityFixtures, SerenityWorkerFixtures>({
+    testDir: './examples',
+    timeout: 30_000,
+    forbidOnly: !!process.env.CI,
+    retries: 0,
+    workers: 1,
+
+    reporter: [
+        [ 'line' ],
+        [
+            path.resolve(__dirname, '../../packages/playwright-test'),    // '@serenity-js/playwright-test'
+            {
+                liveEvents: true,
+                crew: [
+                    '@integration/testing-tools:ChildProcessReporter',
+                    '@serenity-js/core:StreamReporter',
+                    new LiveEventsRecorder(path.resolve(__dirname, 'target/live-events/receipts.json')),
+                ],
+            },
+        ],
+    ],
+
+    use: {
+        cueTimeout: 5_000,
+        actionTimeout: 0,
+        baseURL: 'http://localhost:3000',
+        trace: 'on-first-retry',
+    },
+
+    projects: [
+        {
+            name: 'default',
+            use: {
+                ...devices['Desktop Chrome'],
+                crew: [
+                    // disable Photographer
+                ],
+            },
+        },
+    ],
+});

--- a/integration/playwright-test/spec/events/live_events.spec.ts
+++ b/integration/playwright-test/spec/events/live_events.spec.ts
@@ -1,0 +1,52 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { expect, ifExitCodeIsOtherThan, logOutput } from '@integration/testing-tools';
+import { describe, it } from 'mocha';
+
+import type { EventReceipt } from '../../src/LiveEventsRecorder';
+import { playwrightTest } from '../../src/playwright-test';
+
+describe('Live events', function () {
+
+    const receiptsPath = path.resolve(__dirname, '../../target/live-events/receipts.json');
+
+    it('announces domain events to reporter-side crew members while the scenario is still running, each event exactly once', async () => {
+
+        fs.rmSync(receiptsPath, { force: true });
+
+        const result = await playwrightTest(
+            `--config=${ path.resolve(__dirname, '../../playwright-live-events.config.ts') }`,
+            '--project=default',
+            'live-events/long-running-scenario.spec.ts',
+        ).then(ifExitCodeIsOtherThan(0, logOutput));
+
+        expect(result.exitCode).to.equal(0);
+
+        const receipts: EventReceipt[] = JSON.parse(fs.readFileSync(receiptsPath, 'utf8'));
+
+        const duplicates = receipts
+            .map(receipt => `${ receipt.type }:${ receipt.details }`)
+            .filter((event, index, all) => all.indexOf(event) !== index);
+
+        expect(duplicates, `each event should be announced exactly once`).to.be.empty;
+
+        const indexOfSceneStarts = receipts.findIndex(receipt => receipt.type === 'SceneStarts');
+        const firstInteraction = receipts.find(receipt => receipt.type === 'InteractionFinished' && receipt.details.includes('first interaction'));
+        const secondInteraction = receipts.find(receipt => receipt.type === 'InteractionFinished' && receipt.details.includes('second interaction'));
+
+        expect(indexOfSceneStarts, 'SceneStarts should be announced').to.be.greaterThan(-1);
+        expect(firstInteraction, 'first InteractionFinished should be announced').to.not.be.undefined;
+        expect(secondInteraction, 'second InteractionFinished should be announced').to.not.be.undefined;
+
+        expect(
+            receipts.indexOf(firstInteraction),
+            'SceneStarts should be announced before the first InteractionFinished',
+        ).to.be.greaterThan(indexOfSceneStarts);
+
+        expect(
+            secondInteraction.receivedAt - firstInteraction.receivedAt,
+            'interactions separated by a 2s pause should be received as they happen, not in an end-of-test burst',
+        ).to.be.greaterThan(1_000);
+    });
+});

--- a/integration/playwright-test/src/LiveEventsRecorder.ts
+++ b/integration/playwright-test/src/LiveEventsRecorder.ts
@@ -1,0 +1,41 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+import type { Stage, StageCrewMember } from '@serenity-js/core';
+import { type DomainEvent, TestRunFinished } from '@serenity-js/core/events';
+
+export interface EventReceipt {
+    receivedAt: number;
+    type: string;
+    details: string;
+}
+
+export class LiveEventsRecorder implements StageCrewMember {
+
+    private readonly receipts: EventReceipt[] = [];
+
+    constructor(
+        private readonly outputPath: string,
+        private stage?: Stage,
+    ) {
+    }
+
+    assignedTo(stage: Stage): StageCrewMember {
+        this.stage = stage;
+
+        return this;
+    }
+
+    notifyOf(event: DomainEvent): void {
+        this.receipts.push({
+            receivedAt: Date.now(),
+            type: event.constructor.name,
+            details: JSON.stringify(event.toJSON()),
+        });
+
+        if (event instanceof TestRunFinished) {
+            fs.mkdirSync(path.dirname(this.outputPath), { recursive: true });
+            fs.writeFileSync(this.outputPath, JSON.stringify(this.receipts, undefined, 2));
+        }
+    }
+}

--- a/integration/playwright-test/src/playwright-test.ts
+++ b/integration/playwright-test/src/playwright-test.ts
@@ -31,12 +31,14 @@ export function playwrightTest(...params: string[]): Promise<SpawnResult> {
         ),
     };
 
+    const hasCustomConfig = parameters.some(parameter => parameter.startsWith('--config='));
+
     return spawner(
         playwrightExecutable,
         { cwd: path.resolve(__dirname, '..'), env },
     )(
         'test',
-        `--config=${ path.resolve(__dirname, '../playwright.config.ts') }`,
+        ...(hasCustomConfig ? [] : [ `--config=${ path.resolve(__dirname, '../playwright.config.ts') }` ]),
 
         ...parameters,
     );

--- a/packages/playwright-test/package.json
+++ b/packages/playwright-test/package.json
@@ -148,7 +148,8 @@
     "@serenity-js/web": "workspace:*",
     "axios": "1.18.1",
     "deepmerge": "4.3.1",
-    "tiny-types": "2.0.5"
+    "tiny-types": "2.0.5",
+    "ws": "8.21.0"
   },
   "peerDependencies": {
     "@playwright/test": "~1.61.1"
@@ -162,6 +163,7 @@
     "mocha": "11.7.6",
     "mocha-multi": "1.1.7",
     "ts-node": "10.9.2",
-    "typescript": "5.9.3"
+    "typescript": "5.9.3",
+    "@types/ws": "8.18.1"
   }
 }

--- a/packages/playwright-test/src/api/WorkerEventStreamer.ts
+++ b/packages/playwright-test/src/api/WorkerEventStreamer.ts
@@ -1,0 +1,73 @@
+import type { Stage, StageCrewMember } from '@serenity-js/core';
+import type { DomainEvent } from '@serenity-js/core/events';
+import { WebSocket } from 'ws';
+
+/**
+ * Streams [Serenity/JS domain events](https://serenity-js.org/api/core-events/class/DomainEvent/) that occur in a Playwright Test worker process
+ * to the [`LiveEventsServer`](https://serenity-js.org/api/playwright-test/class/LiveEventsServer/) running in the Playwright Test reporter process,
+ * so that they can be announced to the reporter-side stage crew members as they happen,
+ * rather than when the test is finished.
+ *
+ * Instantiated automatically when [`SerenityReporterForPlaywrightTestConfig.liveEvents`](https://serenity-js.org/api/playwright-test/interface/SerenityReporterForPlaywrightTestConfig/#liveEvents)
+ * is enabled, and disabled otherwise.
+ */
+export class WorkerEventStreamer implements StageCrewMember {
+
+    static readonly environmentVariableName = 'SERENITY_JS_LIVE_EVENTS_URL';
+
+    private socket?: WebSocket;
+    private readonly queue: string[] = [];
+
+    static fromEnvironment(environment: Record<string, string | undefined> = process.env): WorkerEventStreamer {
+        return new WorkerEventStreamer(environment[WorkerEventStreamer.environmentVariableName]);
+    }
+
+    constructor(
+        serverUrl?: string,
+        private stage?: Stage,
+    ) {
+        if (serverUrl) {
+            this.socket = new WebSocket(serverUrl);
+            this.socket.on('open', () => this.flushQueue());
+            this.socket.on('error', () => {
+                this.socket = undefined;
+            });
+        }
+    }
+
+    assignedTo(stage: Stage): StageCrewMember {
+        this.stage = stage;
+
+        return this;
+    }
+
+    notifyOf(event: DomainEvent): void {
+        if (! this.socket) {
+            return;
+        }
+
+        const message = JSON.stringify({ type: event.constructor.name, value: event.toJSON() });
+
+        if (this.socket.readyState === WebSocket.OPEN) {
+            this.socket.send(message);
+        }
+        else if (this.socket.readyState === WebSocket.CONNECTING) {
+            this.queue.push(message);
+        }
+    }
+
+    private flushQueue(): void {
+        this.queue.splice(0).forEach(message => this.socket?.send(message));
+    }
+
+    async close(): Promise<void> {
+        if (! this.socket || this.socket.readyState === WebSocket.CLOSED) {
+            return;
+        }
+
+        await new Promise<void>(resolve => {
+            this.socket.once('close', () => resolve());
+            this.socket.close();
+        });
+    }
+}

--- a/packages/playwright-test/src/api/test-api.ts
+++ b/packages/playwright-test/src/api/test-api.ts
@@ -29,6 +29,7 @@ import { PlaywrightStepReporter, } from '../reporter/index.js';
 import { PlaywrightTestSceneIdFactory } from '../reporter/PlaywrightTestSceneIdFactory.js';
 import { PerformActivitiesAsPlaywrightSteps } from './PerformActivitiesAsPlaywrightSteps.js';
 import type { SerenityFixtures, SerenityWorkerFixtures } from './serenity-fixtures.js';
+import { WorkerEventStreamer } from './WorkerEventStreamer.js';
 import { WorkerEventStreamWriter } from './WorkerEventStreamWriter.js';
 
 interface SerenityInternalFixtures {
@@ -41,6 +42,7 @@ interface SerenityInternalWorkerFixtures {
     sceneIdFactoryInternal: PlaywrightTestSceneIdFactory;
     diffFormatterInternal: DiffFormatter;
     eventStreamWriterInternal: WorkerEventStreamWriter;
+    liveEventStreamerInternal: WorkerEventStreamer;
     workerCastInternal: Cast;
     actorLifecycleManagerInternal: ActorLifecycleManager;
 }
@@ -209,9 +211,22 @@ export const fixtures: Fixtures<SerenityFixtures & SerenityInternalFixtures, Ser
         { scope: 'worker', box: true },
     ],
 
+    liveEventStreamerInternal: [
+        // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
+        async ({}, use) => {
+
+            const liveEventStreamer = WorkerEventStreamer.fromEnvironment();
+
+            await use(liveEventStreamer);
+
+            await liveEventStreamer.close();
+        },
+        { scope: 'worker', box: true },
+    ],
+
     configureWorkerInternal: [
         // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
-        async ({ diffFormatterInternal, eventStreamWriterInternal, extraWorkerAbilities, sceneIdFactoryInternal, serenity, browser }, use, info: WorkerInfo) => {
+        async ({ diffFormatterInternal, eventStreamWriterInternal, extraWorkerAbilities, liveEventStreamerInternal, sceneIdFactoryInternal, serenity, browser }, use, info: WorkerInfo) => {
 
             serenity.configure({
                 actors: Cast.where(actor => {
@@ -228,6 +243,7 @@ export const fixtures: Fixtures<SerenityFixtures & SerenityInternalFixtures, Ser
                 }),
                 crew: [
                     eventStreamWriterInternal,
+                    liveEventStreamerInternal,
                 ],
                 diffFormatter: diffFormatterInternal,
             });

--- a/packages/playwright-test/src/reporter/LiveEventsCoordinator.ts
+++ b/packages/playwright-test/src/reporter/LiveEventsCoordinator.ts
@@ -1,0 +1,90 @@
+import type { DomainEvent } from '@serenity-js/core/events';
+import { CorrelationId } from '@serenity-js/core/model';
+
+/**
+ * Coordinates announcing [Serenity/JS domain events](https://serenity-js.org/api/core-events/class/DomainEvent/) streamed live
+ * from Playwright Test worker processes with the end-of-test flush performed by [`PlaywrightEventBuffer`](https://serenity-js.org/api/playwright-test/class/PlaywrightEventBuffer/),
+ * so that each event is announced to the reporter-side stage crew members exactly once:
+ * - events streamed live for a scene that has already started are announced immediately,
+ * - events streamed live before their scene starts are held back and announced as soon as it does,
+ * - events that could not be delivered live (e.g. those recorded before a worker crashed) are announced by the end-of-test flush,
+ *   which skips any events already announced live.
+ */
+export class LiveEventsCoordinator {
+
+    private readonly announcedEventsByScene = new Map<string, Set<string>>();
+    private readonly pendingEventsByScene = new Map<string, DomainEvent[]>();
+    private readonly startedScenes = new Set<string>();
+    private readonly finishedScenes = new Set<string>();
+
+    constructor(private readonly announce: (...events: DomainEvent[]) => void) {
+    }
+
+    sceneStarted(sceneId: CorrelationId, sceneStartEvents: DomainEvent[]): void {
+        this.startedScenes.add(sceneId.value);
+
+        this.announceAndRecord(sceneId.value, sceneStartEvents);
+
+        const pendingEvents = this.pendingEventsByScene.get(sceneId.value) ?? [];
+        this.pendingEventsByScene.delete(sceneId.value);
+
+        this.announceAndRecord(sceneId.value, pendingEvents);
+    }
+
+    onStreamedEvent(event: DomainEvent): void {
+        const sceneId = this.sceneIdOf(event);
+
+        if (! sceneId || this.finishedScenes.has(sceneId)) {
+            return;
+        }
+
+        if (this.startedScenes.has(sceneId)) {
+            this.announceAndRecord(sceneId, [ event ]);
+            return;
+        }
+
+        this.pendingEventsByScene.set(sceneId, [ ...(this.pendingEventsByScene.get(sceneId) ?? []), event ]);
+    }
+
+    notYetAnnounced(events: DomainEvent[]): DomainEvent[] {
+        return events.filter(event => {
+            const sceneId = this.sceneIdOf(event);
+            const announced = sceneId && this.announcedEventsByScene.get(sceneId);
+
+            return ! announced || ! announced.has(this.serialised(event));
+        });
+    }
+
+    sceneFinished(sceneId: CorrelationId): void {
+        this.finishedScenes.add(sceneId.value);
+        this.announcedEventsByScene.delete(sceneId.value);
+        this.pendingEventsByScene.delete(sceneId.value);
+    }
+
+    sceneFinishedButDeferred(sceneId: CorrelationId): void {
+        this.finishedScenes.add(sceneId.value);
+        this.pendingEventsByScene.delete(sceneId.value);
+    }
+
+    private announceAndRecord(sceneId: string, events: DomainEvent[]): void {
+        if (events.length === 0) {
+            return;
+        }
+
+        const announced = this.announcedEventsByScene.get(sceneId) ?? new Set<string>();
+        events.forEach(event => announced.add(this.serialised(event)));
+        this.announcedEventsByScene.set(sceneId, announced);
+
+        this.announce(...events);
+    }
+
+    private serialised(event: DomainEvent): string {
+        return `${ event.constructor.name }:${ JSON.stringify(event.toJSON()) }`;
+    }
+
+    private sceneIdOf(event: DomainEvent & { sceneId?: CorrelationId }): string | undefined {
+        return event.sceneId instanceof CorrelationId
+            ? event.sceneId.value
+            : undefined;
+    }
+}

--- a/packages/playwright-test/src/reporter/LiveEventsServer.ts
+++ b/packages/playwright-test/src/reporter/LiveEventsServer.ts
@@ -1,0 +1,76 @@
+import type { AddressInfo } from 'node:net';
+
+import type { DomainEvent } from '@serenity-js/core/events';
+import * as events from '@serenity-js/core/events';
+import type { JSONObject } from 'tiny-types';
+import { WebSocketServer } from 'ws';
+
+/**
+ * A WebSocket server running in the Playwright Test reporter process,
+ * receiving [Serenity/JS domain events](https://serenity-js.org/api/core-events/class/DomainEvent/)
+ * streamed by [`WorkerEventStreamer`](https://serenity-js.org/api/playwright-test/class/WorkerEventStreamer/) instances
+ * running in Playwright Test worker processes.
+ *
+ * Instantiated automatically when [`SerenityReporterForPlaywrightTestConfig.liveEvents`](https://serenity-js.org/api/playwright-test/interface/SerenityReporterForPlaywrightTestConfig/#liveEvents)
+ * is enabled.
+ */
+export class LiveEventsServer {
+
+    private server?: WebSocketServer;
+    private readonly listeners: Array<(event: DomainEvent) => void> = [];
+
+    start(): Promise<string> {
+        return new Promise((resolve, reject) => {
+            const server = new WebSocketServer({ host: '127.0.0.1', port: 0 });
+
+            server.on('connection', socket => {
+                socket.on('message', data => {
+                    const event = this.deserialised(String(data));
+                    if (event) {
+                        this.listeners.forEach(listener => listener(event));
+                    }
+                });
+            });
+
+            server.once('listening', () => {
+                this.server = server;
+                const { port } = server.address() as AddressInfo;
+                resolve(`ws://127.0.0.1:${ port }`);
+            });
+
+            server.once('error', (error: Error) => reject(error));
+        });
+    }
+
+    onEvent(listener: (event: DomainEvent) => void): void {
+        this.listeners.push(listener);
+    }
+
+    private deserialised(message: string): DomainEvent | undefined {
+        try {
+            const { type, value } = JSON.parse(message) as { type: string, value: JSONObject };
+            const eventType = events[type];
+
+            return typeof eventType?.fromJSON === 'function'
+                ? eventType.fromJSON(value)
+                : undefined;
+        }
+        catch {
+            return undefined;
+        }
+    }
+
+    async stop(): Promise<void> {
+        if (! this.server) {
+            return;
+        }
+
+        this.server.clients.forEach(client => client.terminate());
+
+        await new Promise<void>((resolve, reject) => {
+            this.server.close(error => error ? reject(error) : resolve());
+        });
+
+        this.server = undefined;
+    }
+}

--- a/packages/playwright-test/src/reporter/PlaywrightEventBuffer.ts
+++ b/packages/playwright-test/src/reporter/PlaywrightEventBuffer.ts
@@ -43,11 +43,15 @@ export class PlaywrightEventBuffer {
         this.eventFactory = new EventFactory(Path.from(config.rootDir));
     }
 
-    appendTestStart(test: TestCase, result: TestResult): void {
+    appendTestStart(test: TestCase, result: TestResult): DomainEvent[] {
+        const sceneStartEvents = this.eventFactory.createSceneStartEvents(test, result);
+
         this.events.set(
             this.sceneId(test, result).value,
-            this.eventFactory.createSceneStartEvents(test, result),
+            sceneStartEvents,
         );
+
+        return [ ...sceneStartEvents ];
     }
 
     appendRetryableSceneEvents(test: TestCase, result: TestResult): void {

--- a/packages/playwright-test/src/reporter/SerenityReporterForPlaywrightTest.ts
+++ b/packages/playwright-test/src/reporter/SerenityReporterForPlaywrightTest.ts
@@ -3,9 +3,13 @@ import type { FullResult, Reporter, Suite, TestCase, TestError, TestResult, } fr
 import type { ClassDescription, StageCrewMember, StageCrewMemberBuilder } from '@serenity-js/core';
 import { Clock, Duration, Serenity, Timestamp } from '@serenity-js/core';
 import type { OutputStream } from '@serenity-js/core/adapter';
-import { TestRunFinished, TestRunFinishes, TestRunStarts } from '@serenity-js/core/events';
-import { ExecutionFailedWithError, ExecutionSuccessful, } from '@serenity-js/core/model';
+import { type DomainEvent, TestRunFinished, TestRunFinishes, TestRunStarts } from '@serenity-js/core/events';
+import { type CorrelationId, ExecutionFailedWithError, ExecutionSuccessful, } from '@serenity-js/core/model';
 
+import { WorkerEventStreamer } from '../api/WorkerEventStreamer.js';
+import { PlaywrightSceneId } from '../events/index.js';
+import { LiveEventsCoordinator } from './LiveEventsCoordinator.js';
+import { LiveEventsServer } from './LiveEventsServer.js';
 import { PlaywrightErrorParser } from './PlaywrightErrorParser.js';
 import { PlaywrightEventBuffer } from './PlaywrightEventBuffer.js';
 import { PlaywrightTestSceneIdFactory } from './PlaywrightTestSceneIdFactory.js';
@@ -40,6 +44,26 @@ export interface SerenityReporterForPlaywrightTestConfig {
      * - [`SerenityConfig.outputStream`](https://serenity-js.org/api/core/class/SerenityConfig/#outputStream)
      */
     outputStream?: OutputStream;
+
+    /**
+     * When enabled, [Serenity/JS domain events](https://serenity-js.org/api/core-events/class/DomainEvent/) that occur in Playwright Test worker processes
+     * are streamed to the reporter process over a WebSocket connection and announced to the [stage crew members](https://serenity-js.org/api/core/interface/StageCrewMember/)
+     * as the scenario executes, rather than when the test is finished.
+     *
+     * This allows crew members to report progress of long-running scenarios in real time,
+     * for example to drive live dashboards or notify external services.
+     *
+     * Events that can't be delivered live, such as those recorded before a worker crashed,
+     * are announced when the test is finished, and each event is announced exactly once.
+     *
+     * Note that with parallel workers, events from concurrently executing scenarios are announced
+     * as they arrive, so crew members receive events from different scenes interleaved
+     * and should correlate them by their `sceneId`.
+     *
+     * Defaults to `false`, in which case all the events for a given scenario are announced together
+     * when the test is finished.
+     */
+    liveEvents?: boolean;
 }
 
 /**
@@ -57,6 +81,9 @@ export class SerenityReporterForPlaywrightTest implements Reporter {
     private readonly eventBuffer: PlaywrightEventBuffer = new PlaywrightEventBuffer();
     private readonly suiteTestCounts = new Map<Suite, number>();
 
+    private liveEventsServer?: LiveEventsServer;
+    private liveEventsCoordinator?: LiveEventsCoordinator;
+
     /**
      * @param config
      */
@@ -69,6 +96,24 @@ export class SerenityReporterForPlaywrightTest implements Reporter {
             this.sceneIdFactory,
         )
         this.serenity.configure(config);
+
+        if (config.liveEvents) {
+            this.liveEventsCoordinator = new LiveEventsCoordinator(
+                (...events) => this.serenity.announce(...events),
+            );
+
+            this.liveEventsServer = new LiveEventsServer();
+            this.liveEventsServer.onEvent(event => this.liveEventsCoordinator.onStreamedEvent(event));
+            this.liveEventsServer.start()
+                .then(serverUrl => {
+                    process.env[WorkerEventStreamer.environmentVariableName] = serverUrl;
+                })
+                .catch(error => {
+                    console.warn(`[SerenityReporterForPlaywrightTest] Couldn't start the live events server, so events will be announced when each test is finished. ${ error }`);
+                    this.liveEventsServer = undefined;
+                    this.liveEventsCoordinator = undefined;
+                });
+        }
     }
 
     onBegin(config: FullConfig, suite: Suite): void {
@@ -91,7 +136,9 @@ export class SerenityReporterForPlaywrightTest implements Reporter {
     }
 
     onTestBegin(test: TestCase, result: TestResult): void {
-        this.eventBuffer.appendTestStart(test, result);
+        const sceneStartEvents = this.eventBuffer.appendTestStart(test, result);
+
+        this.liveEventsCoordinator?.sceneStarted(this.sceneId(test, result), sceneStartEvents);
     }
 
     // TODO might be nice to support that by emitting TestStepStarted / Finished
@@ -120,11 +167,25 @@ export class SerenityReporterForPlaywrightTest implements Reporter {
 
             const events = this.eventBuffer.flush(test, result);
 
-            this.serenity.announce(...events);
+            this.serenity.announce(...this.notYetAnnounced(events));
+
+            this.liveEventsCoordinator?.sceneFinished(this.sceneId(test, result));
         }
         else {
             this.eventBuffer.deferAppendingSceneFinishedEvent(test, result);
+
+            this.liveEventsCoordinator?.sceneFinishedButDeferred(this.sceneId(test, result));
         }
+    }
+
+    private sceneId(test: TestCase, result: TestResult): CorrelationId {
+        return PlaywrightSceneId.from(test.parent.project()?.name, test, result);
+    }
+
+    private notYetAnnounced(events: DomainEvent[]): DomainEvent[] {
+        return this.liveEventsCoordinator
+            ? this.liveEventsCoordinator.notYetAnnounced(events)
+            : events;
     }
 
     private countPendingAfterAllHooks(test: TestCase): number {
@@ -153,10 +214,15 @@ export class SerenityReporterForPlaywrightTest implements Reporter {
 
     async onEnd(fullResult: FullResult): Promise<void> {
 
+        if (this.liveEventsServer) {
+            await this.liveEventsServer.stop();
+            delete process.env[WorkerEventStreamer.environmentVariableName];
+        }
+
         const deferredEvents = this.eventBuffer.flushAllDeferred();
 
         this.serenity.announce(
-            ...deferredEvents,
+            ...this.notYetAnnounced(deferredEvents),
         );
 
         const fullDuration = Duration.ofMilliseconds(Math.round(fullResult.duration));

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2953,6 +2953,9 @@ importers:
       tiny-types:
         specifier: 2.0.5
         version: 2.0.5
+      ws:
+        specifier: 8.21.0
+        version: 8.21.0
     devDependencies:
       '@integration/testing-tools':
         specifier: workspace:*
@@ -2966,6 +2969,9 @@ importers:
       '@types/mocha':
         specifier: 10.0.10
         version: 10.0.10
+      '@types/ws':
+        specifier: 8.18.1
+        version: 8.18.1
       c8:
         specifier: 11.0.0
         version: 11.0.0


### PR DESCRIPTION
## Summary

Spike implementation of the live event streaming discussed in #3292, following the shape @jan-molak proposed there: a WebSocket channel between Playwright Test worker processes and the Serenity/JS reporter process, so that reporter-side stage crew members receive domain events while the scenario is still running rather than when the test is finished.

## How it works

- `@serenity-js/playwright-test` accepts an opt-in `liveEvents: true` reporter option
- When enabled, `SerenityReporterForPlaywrightTest` starts a `LiveEventsServer` (WebSocket, ephemeral localhost port) and shares its URL with workers via an environment variable
- Each worker registers a `WorkerEventStreamer` crew member, alongside the existing `WorkerEventStreamWriter`, that pushes each domain event to the server as it happens
- The reporter announces streamed events to its stage immediately; `LiveEventsCoordinator` guarantees ordering and exactly-once delivery:
  - events arriving before the reporter has seen `onTestBegin` for their scene are held back and announced right after the scene-start events, so crew members never see an interaction before `SceneStarts`
  - the end-of-test flush from `PlaywrightEventBuffer` still runs, but skips anything already announced live; anything the live path couldn't deliver (crashed workers, deferred `afterAll` hooks) is still back-filled
- Defaults to `false`, in which case behaviour is unchanged

## Design decisions open to discussion

- The disk-based `WorkerEventStreamWriter` is untouched; the WebSocket stream sits alongside it rather than replacing it
- Dedup between the live stream and the buffered flush is keyed on the serialised event (`constructor.name` + `toJSON()`) rather than `equals()`, because events such as `ActorEntersStage` carry plain serialised-actor objects that `equals()` compares by reference
- With parallel workers, crew members receive events from concurrent scenes interleaved, correlated by `sceneId`
- `liveEvents` is a plain boolean for now; it could grow into `{ port }` or similar to let external subscribers connect directly

## Testing

- New integration test (`integration/playwright-test/spec/events/live_events.spec.ts`) covering ordering, exactly-once delivery, and actual liveness: two interactions separated by a two-second pause must be received more than a second apart, which fails under the buffered behaviour
- Full `@integration/playwright-test` suite passes (66 specs)
- Adds one dependency to `@serenity-js/playwright-test`: `ws@8.21.0` (already present in the workspace lockfile)