### PR TITLE
ci(github): use Docker container for unit tests and Playwright integration jobs

### DIFF
--- a/.github/actions/setup-node-container/action.yaml
+++ b/.github/actions/setup-node-container/action.yaml
@@ -1,0 +1,49 @@
+name: 'Set up Node (container)'
+description: 'Sets up Node.js inside the pre-built Serenity/JS container (browsers already installed)'
+
+inputs:
+  install:
+    description: 'Whether to install npm dependencies'
+    required: false
+    default: 'true'
+  browsers:
+    description: 'Which browsers to install: none, protractor, webdriverio, all'
+    required: false
+    default: 'none'
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Mark workspace as safe for git
+      shell: bash
+      run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
+
+    - name: Install system tools
+      shell: bash
+      run: |
+        sudo apt-get update -qq
+        sudo apt-get install -y --no-install-recommends make p7zip-full xz-utils
+
+    - name: Install pnpm
+      uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6
+
+    - name: Setup Node
+      uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+      with:
+        node-version: '24.x'
+        cache: 'pnpm'
+
+    - name: Install dependencies
+      if: inputs.install == 'true'
+      shell: bash
+      run: pnpm install --frozen-lockfile
+
+    - name: Install Protractor browsers
+      if: inputs.browsers == 'protractor' || inputs.browsers == 'all'
+      shell: bash
+      run: pnpm setup:protractor
+
+    - name: Install WebdriverIO browsers
+      if: inputs.browsers == 'webdriverio' || inputs.browsers == 'all'
+      shell: bash
+      run: pnpm setup:webdriverio

--- a/.github/actions/setup-node/action.yaml
+++ b/.github/actions/setup-node/action.yaml
@@ -23,3 +23,7 @@ runs:
     - name: Install dependencies
       shell: bash
       run: pnpm install --frozen-lockfile
+
+    - name: Install browsers
+      shell: bash
+      run: pnpm setup

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -15,22 +15,26 @@ jobs:
   lint:
     name: 'Lint'
     runs-on: ubuntu-24.04
+    container:
+      image: ghcr.io/serenity-js/playwright:v1.62.1-resolute
     steps:
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - name: Set up Node
-        uses: ./.github/actions/setup-node
+        uses: ./.github/actions/setup-node-container
       - name: Lint
         run: make lint
 
   compile:
     name: 'Compile'
     runs-on: ubuntu-24.04
+    container:
+      image: ghcr.io/serenity-js/playwright:v1.62.1-resolute
     steps:
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - name: Set up Node
-        uses: ./.github/actions/setup-node
+        uses: ./.github/actions/setup-node-container
       - name: Compile
         run: make COMPILE_SCOPE=libs compile
       - name: Upload compiled libs
@@ -49,6 +53,8 @@ jobs:
       - lint
       - compile
     runs-on: ubuntu-24.04
+    container:
+      image: ghcr.io/serenity-js/playwright:v1.62.1-resolute
     permissions:
       checks: write
       contents: read
@@ -57,7 +63,9 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - name: Set up Node
-        uses: ./.github/actions/setup-node
+        uses: ./.github/actions/setup-node-container
+        with:
+          browsers: 'protractor'
       - name: Download compiled libs
         uses: ./.github/actions/download-compressed-artifact
         with:
@@ -120,6 +128,8 @@ jobs:
       - lint
       - compile
     runs-on: ubuntu-24.04
+    container:
+      image: ghcr.io/serenity-js/playwright:v1.62.1-resolute
     permissions:
       checks: write
       contents: read
@@ -137,7 +147,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - name: Set up Node
-        uses: ./.github/actions/setup-node
+        uses: ./.github/actions/setup-node-container
       - name: Set up Java
         uses: ./.github/actions/setup-java
       - name: Download compiled libs
@@ -176,6 +186,8 @@ jobs:
       - lint
       - compile
     runs-on: ubuntu-24.04
+    container:
+      image: ghcr.io/serenity-js/playwright:v1.62.1-resolute
     permissions:
       checks: write
       contents: read
@@ -190,7 +202,9 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - name: Set up Node
-        uses: ./.github/actions/setup-node
+        uses: ./.github/actions/setup-node-container
+        with:
+          browsers: 'protractor'
       - name: Set up Java
         uses: ./.github/actions/setup-java
       - name: Download compiled libs
@@ -229,6 +243,8 @@ jobs:
       - lint
       - compile
     runs-on: ubuntu-24.04
+    container:
+      image: ghcr.io/serenity-js/playwright:v1.62.1-resolute
     permissions:
       checks: write
       contents: read
@@ -246,7 +262,9 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - name: Set up Node
-        uses: ./.github/actions/setup-node
+        uses: ./.github/actions/setup-node-container
+        with:
+          browsers: 'webdriverio'
       - name: Set up Java
         uses: ./.github/actions/setup-java
       - name: Download compiled libs
@@ -285,6 +303,8 @@ jobs:
       - lint
       - compile
     runs-on: ubuntu-24.04
+    container:
+      image: ghcr.io/serenity-js/playwright:v1.62.1-resolute
     permissions:
       checks: write
       contents: read
@@ -314,7 +334,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - name: Set up Node
-        uses: ./.github/actions/setup-node
+        uses: ./.github/actions/setup-node-container
       - name: Download compiled libs
         uses: ./.github/actions/download-compressed-artifact
         with:
@@ -381,11 +401,13 @@ jobs:
       - test-integration-protractor
       - test-integration-webdriverio
     runs-on: ubuntu-24.04
+    container:
+      image: ghcr.io/serenity-js/playwright:v1.62.1-resolute
     steps:
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - name: Set up Node
-        uses: ./.github/actions/setup-node
+        uses: ./.github/actions/setup-node-container
       - name: Download compiled libs
         uses: ./.github/actions/download-compressed-artifact
         with:
@@ -430,6 +452,8 @@ jobs:
       contents: write
       id-token: write
     runs-on: ubuntu-24.04
+    container:
+      image: ghcr.io/serenity-js/playwright:v1.62.1-resolute
     needs:
       - test-linux-node-lts-active
       - test-linux-node-lts-maintenance
@@ -456,7 +480,7 @@ jobs:
         run: 7z x -aoa compiled-libs.zip
 
       - name: Set up Node
-        uses: ./.github/actions/setup-node
+        uses: ./.github/actions/setup-node-container
 
       - name: Publish artifacts
         run: pnpm lerna:publish

--- a/.kiro/steering/debugging-ci.md
+++ b/.kiro/steering/debugging-ci.md
@@ -62,12 +62,13 @@ npx tsc --noEmit
 
 ### Browser Installation
 
-Browsers install automatically during `make install`. To reinstall manually:
+Browsers are installed separately from npm dependencies via `make setup` or `pnpm setup`. This is a one-off step — re-run it only when Playwright or Chrome versions are updated:
 
 ```bash
-pnpm postinstall:playwright    # Playwright browsers
-pnpm postinstall:protractor    # Chrome v129 for Protractor
-pnpm postinstall:webdriverio   # Chrome stable for WebdriverIO
+make setup                     # all browsers
+pnpm setup:playwright          # Playwright browsers + OS deps
+pnpm setup:protractor          # Chrome 129 + ChromeDriver (for Protractor tests)
+pnpm setup:webdriverio         # Chrome stable + ChromeDriver (for WebdriverIO tests)
 ```
 
 ### Dual CJS/ESM Builds

--- a/.kiro/steering/project-overview.md
+++ b/.kiro/steering/project-overview.md
@@ -115,7 +115,8 @@ dependencies follow the dependency rule: abstractions never depend on concretion
 ## Build Commands
 
 ```bash
-make install                                    # Install deps + browsers
+make install                                    # Install npm deps (no browsers)
+make setup                                      # Install browsers (one-off, or after Playwright/Chrome update)
 make compile                                    # Compile all packages
 make COMPILE_SCOPE=libs compile                 # Compile library packages only
 make test                                       # Unit tests with coverage

--- a/Makefile
+++ b/Makefile
@@ -32,12 +32,15 @@ COMPILE_SCOPE=all
 # webdriverio-web
 INTEGRATION_SCOPE=all
 
-.PHONY: all install clean lint test compile integration-test verify
+.PHONY: all install clean lint test compile integration-test verify setup
 all: install clean compile
 
 install:
 	corepack enable
 	pnpm install --frozen-lockfile
+
+setup:
+	pnpm setup
 
 update-pnpm:
 	corepack use pnpm@latest

--- a/integration/webdriverio-8-cucumber/examples/wdio.conf.ts
+++ b/integration/webdriverio-8-cucumber/examples/wdio.conf.ts
@@ -57,6 +57,7 @@ export const config: WebdriverIOConfig = {
             args: [
                 'headless',
                 'no-sandbox',
+                'disable-dev-shm-usage',
                 'disable-gpu',
                 'window-size=1024x768',
             ],

--- a/integration/webdriverio-8-jasmine/examples/wdio.afterTest.conf.ts
+++ b/integration/webdriverio-8-jasmine/examples/wdio.afterTest.conf.ts
@@ -44,6 +44,7 @@ export const config: WebdriverIOConfig = {
             args: [
                 'headless',
                 'no-sandbox',
+                'disable-dev-shm-usage',
                 'disable-gpu',
                 'window-size=1024x768',
             ],

--- a/integration/webdriverio-8-jasmine/examples/wdio.conf.ts
+++ b/integration/webdriverio-8-jasmine/examples/wdio.conf.ts
@@ -41,6 +41,7 @@ export const config: WebdriverIOConfig = {
             args: [
                 'headless',
                 'no-sandbox',
+                'disable-dev-shm-usage',
                 'disable-gpu',
                 'window-size=1024x768',
             ],

--- a/integration/webdriverio-8-mocha/examples/wdio.afterTest.conf.ts
+++ b/integration/webdriverio-8-mocha/examples/wdio.afterTest.conf.ts
@@ -53,6 +53,7 @@ export const config: WebdriverIOConfig = {
             args: [
                 'headless',
                 'no-sandbox',
+                'disable-dev-shm-usage',
                 'disable-gpu',
                 'window-size=1024x768',
             ],

--- a/integration/webdriverio-8-mocha/examples/wdio.conf.ts
+++ b/integration/webdriverio-8-mocha/examples/wdio.conf.ts
@@ -50,6 +50,7 @@ export const config: WebdriverIOConfig = {
             args: [
                 'headless',
                 'no-sandbox',
+                'disable-dev-shm-usage',
                 'disable-gpu',
                 'window-size=1024x768',
             ],

--- a/integration/webdriverio-8-mocha/examples/wdio.html-reporter-parallel.conf.ts
+++ b/integration/webdriverio-8-mocha/examples/wdio.html-reporter-parallel.conf.ts
@@ -53,6 +53,7 @@ export const config: WebdriverIOConfig = {
             args: [
                 'headless',
                 'no-sandbox',
+                'disable-dev-shm-usage',
                 'disable-gpu',
                 'window-size=1024x768',
             ],

--- a/integration/webdriverio-8-web/wdio.conf.ts
+++ b/integration/webdriverio-8-web/wdio.conf.ts
@@ -44,6 +44,7 @@ const options = {
             excludeSwitches: [ 'enable-automation' ],
             args: [
                 'no-sandbox',
+                'disable-dev-shm-usage',
                 'disable-web-security',
                 'allow-file-access-from-files',
                 'allow-file-access',

--- a/integration/webdriverio-cucumber/examples/wdio.conf.ts
+++ b/integration/webdriverio-cucumber/examples/wdio.conf.ts
@@ -37,6 +37,7 @@ export const config: WebdriverIO.Config & WithSerenityConfig = {
     ],
 
     runner: 'local',
+    autoXvfb: false,
 
     maxInstances: 1,
 

--- a/integration/webdriverio-cucumber/examples/wdio.conf.ts
+++ b/integration/webdriverio-cucumber/examples/wdio.conf.ts
@@ -49,6 +49,7 @@ export const config: WebdriverIO.Config & WithSerenityConfig = {
             args: [
                 'headless',
                 'no-sandbox',
+                'disable-dev-shm-usage',
                 'disable-gpu',
                 'window-size=1024x768',
             ],

--- a/integration/webdriverio-jasmine/examples/wdio.afterTest.conf.ts
+++ b/integration/webdriverio-jasmine/examples/wdio.afterTest.conf.ts
@@ -1,59 +1,10 @@
-import { StdOutReporter } from '@integration/testing-tools';
-import { Duration, NoOpDiffFormatter } from '@serenity-js/core';
-import { WithSerenityConfig } from '@serenity-js/webdriverio';
+import { config as baseConfig } from './wdio.conf';
 
 // Marker prefix for afterTest hook output, used by integration tests to verify hook invocation
 const AFTER_TEST_MARKER = '[AfterTest]';
 
-export const config: WebdriverIO.Config & WithSerenityConfig = {
-
-    framework: '@serenity-js/webdriverio',
-
-    serenity: {
-        runner: 'jasmine',
-        diffFormatter: new NoOpDiffFormatter(),
-        crew: [
-            new StdOutReporter(),
-        ],
-        cueTimeout: Duration.ofSeconds(1),
-    },
-
-    mochaOpts: {
-        ui: 'bdd',
-        timeout: 60000,
-    },
-
-    specs: [ ], // specified in tests themselves to avoid loading more than needed
-
-    reporters: [
-        'spec',
-    ],
-
-    runner: 'local',
-
-    maxInstances: 1,
-
-    capabilities: [{
-
-        browserName: 'chrome',
-        'goog:chromeOptions': {
-            excludeSwitches: [ 'enable-automation' ],
-            args: [
-                'headless',
-                'no-sandbox',
-                'disable-gpu',
-                'window-size=1024x768',
-            ],
-        }
-    }],
-
-    logLevel: 'debug',
-
-    waitforTimeout: 10000,
-
-    connectionRetryTimeout: 90000,
-
-    connectionRetryCount: 3,
+export const config: typeof baseConfig = {
+    ...baseConfig,
 
     /**
      * Hook that gets executed after a test (in Mocha/Jasmine only)

--- a/integration/webdriverio-jasmine/examples/wdio.conf.ts
+++ b/integration/webdriverio-jasmine/examples/wdio.conf.ts
@@ -27,6 +27,7 @@ export const config: WebdriverIO.Config & WithSerenityConfig = {
     ],
 
     runner: 'local',
+    autoXvfb: false,
 
     maxInstances: 1,
 

--- a/integration/webdriverio-jasmine/examples/wdio.conf.ts
+++ b/integration/webdriverio-jasmine/examples/wdio.conf.ts
@@ -39,6 +39,7 @@ export const config: WebdriverIO.Config & WithSerenityConfig = {
             args: [
                 'headless',
                 'no-sandbox',
+                'disable-dev-shm-usage',
                 'disable-gpu',
                 'window-size=1024x768',
             ],

--- a/integration/webdriverio-jasmine/examples/wdio.html-reporter-parallel.conf.ts
+++ b/integration/webdriverio-jasmine/examples/wdio.html-reporter-parallel.conf.ts
@@ -1,17 +1,14 @@
 import path from 'node:path';
 
-import { NoOpDiffFormatter } from '@serenity-js/core';
-import { WithSerenityConfig } from '@serenity-js/webdriverio';
+import { config as baseConfig } from './wdio.conf';
 
 const outputDirectory = path.resolve(__dirname, '..', 'target', 'html-report-parallel');
 
-export const config: WebdriverIO.Config & WithSerenityConfig = {
-
-    framework: '@serenity-js/webdriverio',
+export const config: typeof baseConfig = {
+    ...baseConfig,
 
     serenity: {
-        runner: 'jasmine',
-        diffFormatter: new NoOpDiffFormatter(),
+        ...baseConfig.serenity,
         crew: [
             ['@serenity-js/html-reporter', {
                 outputDirectory,
@@ -19,35 +16,7 @@ export const config: WebdriverIO.Config & WithSerenityConfig = {
         ],
     },
 
-    specs: [], // specified via --spec CLI arguments to ensure correct path resolution
-
-    reporters: [
-        'spec',
-    ],
-
-    runner: 'local',
-
     maxInstances: 2,
 
-    capabilities: [{
-
-        browserName: 'chrome',
-        'goog:chromeOptions': {
-            excludeSwitches: [ 'enable-automation' ],
-            args: [
-                'headless',
-                'no-sandbox',
-                'disable-gpu',
-                'window-size=1024x768',
-            ],
-        }
-    }],
-
     logLevel: 'warn',
-
-    waitforTimeout: 10000,
-
-    connectionRetryTimeout: 90000,
-
-    connectionRetryCount: 3,
 };

--- a/integration/webdriverio-mocha/examples/wdio.afterTest.conf.ts
+++ b/integration/webdriverio-mocha/examples/wdio.afterTest.conf.ts
@@ -1,65 +1,10 @@
-import * as path from 'node:path';
-
-import { StdOutReporter } from '@integration/testing-tools';
-import { Duration, NoOpDiffFormatter } from '@serenity-js/core';
-import { WithSerenityConfig } from '@serenity-js/webdriverio';
+import { config as baseConfig } from './wdio.conf';
 
 // Marker prefix for afterTest hook output, used by integration tests to verify hook invocation
 const AFTER_TEST_MARKER = '[AfterTest]';
 
-export const config: WebdriverIO.Config & WithSerenityConfig = {
-
-    framework: '@serenity-js/webdriverio',
-
-    serenity: {
-        runner: 'mocha',
-        diffFormatter: new NoOpDiffFormatter(),
-        crew: [
-            new StdOutReporter(),
-        ],
-        cueTimeout: Duration.ofSeconds(1),
-    },
-
-    mochaOpts: {
-        ui: 'bdd',
-        timeout: 60000,
-    },
-
-    specs: [ ], // specified in tests themselves to avoid loading more than needed
-
-    reporters: [
-        'spec',
-    ],
-
-    tsConfigPath: path.resolve(__dirname, './tsconfig.json'),
-
-    runner: 'local',
-
-    maxInstances: 1,
-
-    headless: true,
-
-    capabilities: [{
-
-        browserName: 'chrome',
-        'goog:chromeOptions': {
-            excludeSwitches: [ 'enable-automation' ],
-            args: [
-                'headless',
-                'no-sandbox',
-                'disable-gpu',
-                'window-size=1024x768',
-            ],
-        }
-    }],
-
-    logLevel: 'debug',
-
-    waitforTimeout: 10000,
-
-    connectionRetryTimeout: 90000,
-
-    connectionRetryCount: 3,
+export const config: typeof baseConfig = {
+    ...baseConfig,
 
     /**
      * Hook that gets executed after a test (in Mocha/Jasmine only)

--- a/integration/webdriverio-mocha/examples/wdio.conf.ts
+++ b/integration/webdriverio-mocha/examples/wdio.conf.ts
@@ -31,6 +31,7 @@ export const config: WebdriverIO.Config & WithSerenityConfig = {
     tsConfigPath: resolve(__dirname, './tsconfig.json'),
 
     runner: 'local',
+    autoXvfb: false,
 
     maxInstances: 1,
 

--- a/integration/webdriverio-mocha/examples/wdio.conf.ts
+++ b/integration/webdriverio-mocha/examples/wdio.conf.ts
@@ -45,6 +45,7 @@ export const config: WebdriverIO.Config & WithSerenityConfig = {
             args: [
                 'headless',
                 'no-sandbox',
+                'disable-dev-shm-usage',
                 'disable-gpu',
                 'window-size=1024x768',
             ],

--- a/integration/webdriverio-web/wdio.conf.ts
+++ b/integration/webdriverio-web/wdio.conf.ts
@@ -70,6 +70,7 @@ export const config: WebdriverIO.Config & WithSerenityConfig = {
     ],
 
     runner: 'local',
+    autoXvfb: false,
 
     waitforTimeout: 10_000,
     connectionRetryTimeout: 30_000,

--- a/integration/webdriverio-web/wdio.conf.ts
+++ b/integration/webdriverio-web/wdio.conf.ts
@@ -81,6 +81,7 @@ export const config: WebdriverIO.Config & WithSerenityConfig = {
             binary: binaries.chrome,
             excludeSwitches: [ 'enable-automation' ],
             args: [
+                'disable-dev-shm-usage',
                 'disable-web-security',
                 'allow-file-access-from-files',
                 'allow-file-access',

--- a/package.json
+++ b/package.json
@@ -24,10 +24,10 @@
     "testing"
   ],
   "scripts": {
-    "postinstall": "pnpm postinstall:protractor && pnpm postinstall:playwright && pnpm postinstall:webdriverio",
-    "postinstall:playwright": "npx playwright install --with-deps",
-    "postinstall:protractor": "npx tsx bin/install-browsers.ts chrome@129.0.6668.100 chromedriver@129.0.6668.100",
-    "postinstall:webdriverio": "npx tsx bin/install-browsers.ts chrome@stable chromedriver@stable",
+    "setup": "pnpm setup:protractor && pnpm setup:playwright && pnpm setup:webdriverio",
+    "setup:playwright": "npx playwright install --with-deps",
+    "setup:protractor": "npx tsx bin/install-browsers.ts chrome@129.0.6668.100 chromedriver@129.0.6668.100",
+    "setup:webdriverio": "npx tsx bin/install-browsers.ts chrome@stable chromedriver@stable",
     "clean": "rimraf target && lerna run clean",
     "cc": "nx reset",
     "lint": "eslint .",

--- a/protractor.conf.js
+++ b/protractor.conf.js
@@ -55,6 +55,7 @@ module.exports = {
             excludeSwitches: [ 'enable-automation' ],
             args: [
                 'no-sandbox',
+                'disable-dev-shm-usage',
                 'disable-web-security',
                 'allow-file-access-from-files',
                 'allow-file-access',


### PR DESCRIPTION
Use ghcr.io/serenity-js/playwright:v1.62.1-resolute container for test-linux-node-lts-active and test-integration-playwright jobs.

The container has all Playwright browsers and OS dependencies pre-installed, eliminating the slow postinstall step that runs `npx playwright install --with-deps` (which hangs for 18+ minutes when Azure Ubuntu mirrors are unreachable).

Adds a new setup-node-container composite action that uses `pnpm install --ignore-scripts` since browsers are already present.