### PR TITLE
fix(html-reporter): corrected retry attempts reporting and report title fallback logic

### DIFF
--- a/examples/playwright-test-todomvc/playwright.config.ts
+++ b/examples/playwright-test-todomvc/playwright.config.ts
@@ -36,14 +36,15 @@ export default defineConfig<SerenityFixtures, SerenityWorkerFixtures>({
     /* Reporter to use. See https://playwright.dev/docs/test-reporters */
     reporter: [
         [ 'line' ],
-        [ 'html', { open: 'never' } ],
+        ['html', { open: 'never', outputFolder: './reports/playwright' }],
         [ '@serenity-js/playwright-test', {
             crew: [
                 [ '@serenity-js/serenity-bdd', { reporter: { includeAbilityDetails: true } } ],
                 // '@serenity-js/console-reporter',
                 [ '@serenity-js/core:ArtifactArchiver', { outputDirectory: 'target/site/serenity' } ],
                 [ '@serenity-js/html-reporter', {
-                    outputDirectory: 'reports/serenity',
+                    outputDirectory: 'reports/serenity-js',
+                    title: 'My Playwright Test Project',
                     specDirectory: './spec',
                     maxHistory: 10,
                 }

--- a/examples/playwright-test-todomvc/spec/failing.spec.ts
+++ b/examples/playwright-test-todomvc/spec/failing.spec.ts
@@ -1,0 +1,22 @@
+import { Ensure, equals } from '@serenity-js/assertions';
+import { describe, it } from '@serenity-js/playwright-test';
+
+import { startWithAnEmptyList } from './todo-list-app/TodoApp';
+import { recordItem } from './todo-list-app/TodoItem';
+
+describe('Flaky', () => {
+
+    describe('Todo List App', () => {
+
+        it('should sometimes work, and sometimes not', async ({ actor }, info) => {
+            const shouldPass = Math.random() < 0.9;
+
+            await actor.attemptsTo(
+                startWithAnEmptyList(),
+
+                recordItem(`Should ${ shouldPass ? 'pass' : 'fail' } on attempt #${ info.retry + 1 }`),
+                Ensure.that(shouldPass, equals(true)),
+            );
+        });
+    });
+});

--- a/examples/playwright-test-todomvc/spec/failing.spec.ts
+++ b/examples/playwright-test-todomvc/spec/failing.spec.ts
@@ -1,22 +1,12 @@
-import { Ensure, equals } from '@serenity-js/assertions';
+import { TestCompromisedError } from '@serenity-js/core';
 import { describe, it } from '@serenity-js/playwright-test';
-
-import { startWithAnEmptyList } from './todo-list-app/TodoApp';
-import { recordItem } from './todo-list-app/TodoItem';
 
 describe('Flaky', () => {
 
     describe('Todo List App', () => {
 
-        it('should sometimes work, and sometimes not', async ({ actor }, info) => {
-            const shouldPass = Math.random() < 0.9;
-
-            await actor.attemptsTo(
-                startWithAnEmptyList(),
-
-                recordItem(`Should ${ shouldPass ? 'pass' : 'fail' } on attempt #${ info.retry + 1 }`),
-                Ensure.that(shouldPass, equals(true)),
-            );
+        it('should demonstrate a failing test', async ({ actor }, info) => {
+            throw new TestCompromisedError('Example error');
         });
     });
 });

--- a/packages/core/src/io/proxies.ts
+++ b/packages/core/src/io/proxies.ts
@@ -3,7 +3,7 @@ export interface Dictionary {
 }
 
 /**
- * @private
+ * @internal
  */
 export function caseInsensitive<T extends Dictionary>(dictionary: T): T & Dictionary {
     return new Proxy(dictionary, {

--- a/packages/html-reporter/README.md
+++ b/packages/html-reporter/README.md
@@ -118,11 +118,11 @@ All options are optional. See the [`HtmlReporterConfig` API reference](https://s
 | Option              | Type     | Default                 | Description                                                   |
 |---------------------|----------|-------------------------|---------------------------------------------------------------|
 | `outputDirectory`   | `string` | `./reports/serenity-js` | Where the report is generated                                 |
-| `title`             | `string` | —                       | Report title shown in the header                              |
+| `title`             | `string` | —                       | Report title shown in the header. Falls back to `projectName`, then test runner name. |
 | `specDirectory`     | `string` | auto-detected           | Root of your specs, used to build the [requirements hierarchy](https://serenity-js.org/handbook/reporting/html-reporter/#the-requirements-hierarchy)  |
 | `maxHistory`        | `number` | —                       | Maximum test runs to retain (older runs are pruned)           |
 | `consistencyWindow` | `number` | `5`                     | Number of recent runs used to detect flaky tests              |
-| `projectName`       | `string` | auto-detected           | Project name shown in the System Context view (defaults to the closest `package.json` name) |
+| `projectName`       | `string` | auto-detected           | Project name (from closest `package.json`). Used as `title` fallback and shown in System Context view. |
 | `testRunId`         | `string` | auto-detected           | Test run directory identifier (defaults to CI build number or ISO timestamp) |
 | `moduleId`          | `string` | auto-detected           | Module identifier for parallel CI job shards (defaults to working directory name when a CI build number is detected) |
 | `ci`                | `object` | auto-detected           | Override CI/CD context (see fields below)                     |

--- a/packages/html-reporter/spec/cli/aggregation/SingleSourceAggregator.spec.ts
+++ b/packages/html-reporter/spec/cli/aggregation/SingleSourceAggregator.spec.ts
@@ -202,6 +202,32 @@ test.describe('SingleSourceAggregator', () => {
             expect(data.summary.title).toBe('My Project Report');
         });
 
+        test('falls back to projectName from systemContext when title is not configured', () => {
+            const { aggregator, filesystem } = createAggregator({
+                'test-runs': {
+                    '2024-06-15T14:30:00.000Z': {
+                        'db.json': runData({
+                            startedAt: '2024-06-15T14:30:00.000Z', finishedAt: '2024-06-15T14:30:00.100Z',
+                            outcomes: { passed: 1, failed: 0, pending: 0, skipped: 0, compromised: 0, error: 0 },
+                            scenes: [{ name: 'Test', category: 'Suite', outcome: { code: 64 }, duration: 100, startedAt: '2024-06-15T14:30:00.000Z', source: { path: 'a.spec.ts', line: 1 }, tags: [], activities: [] }],
+                            tags: [], testRunner: { name: 'Playwright', version: '1.62.0' },
+                            systemContext: {
+                                nodeVersion: 'v22.0.0',
+                                os: { name: 'darwin', version: '24.0.0', arch: 'arm64' },
+                                serenityVersion: '3.45.8',
+                                projectName: 'my-checkout-service',
+                            },
+                        }),
+                    },
+                },
+            }); // no title in config
+
+            aggregator.aggregate();
+
+            const data = readDataJs(filesystem);
+            expect(data.summary.title).toBe('my-checkout-service');
+        });
+
         test('includes system context from the latest run in the data snapshot', () => {
             const { aggregator, filesystem } = createAggregator({
                 'test-runs': {

--- a/packages/html-reporter/spec/cli/collection/SceneDataCollector.spec.ts
+++ b/packages/html-reporter/spec/cli/collection/SceneDataCollector.spec.ts
@@ -22,6 +22,7 @@ import {
     Description,
     ExecutionFailedWithAssertionError,
     ExecutionFailedWithError,
+    ExecutionIgnored,
     ExecutionSuccessful,
     HTTPRequestResponse,
     JSONData,
@@ -106,6 +107,70 @@ test.describe('SceneDataCollector', () => {
             expect(scene.attempts[1].activities).toHaveLength(1);
             expect(scene.attempts[1].activities[0].name).toBe('Tess ensures that 2 does equal 2');
             expect(scene.attempts[1].error).toBeUndefined();
+        });
+
+        test('records ExecutionIgnored attempts as failures when test consistently fails across retries', () => {
+            const collector = new SceneDataCollector();
+            const queues = new DomainEventQueues();
+
+            const details = new ScenarioDetails(
+                new Name('should fail consistently'),
+                new Category('Todo List App'),
+                new FileSystemLocation(Path.from('spec/failing.spec.ts'), 5, 1),
+            );
+            const sceneId = CorrelationId.create();
+
+            const t0 = new Timestamp(new Date('2024-01-01T00:00:00.000Z'));
+            const t1 = new Timestamp(new Date('2024-01-01T00:00:00.050Z'));
+            const t2 = new Timestamp(new Date('2024-01-01T00:00:00.100Z'));
+            const t3 = new Timestamp(new Date('2024-01-01T00:00:00.200Z'));
+            const t4 = new Timestamp(new Date('2024-01-01T00:00:00.250Z'));
+            const t5 = new Timestamp(new Date('2024-01-01T00:00:00.300Z'));
+            const t6 = new Timestamp(new Date('2024-01-01T00:00:00.400Z'));
+            const t7 = new Timestamp(new Date('2024-01-01T00:00:00.450Z'));
+            const t8 = new Timestamp(new Date('2024-01-01T00:00:00.500Z'));
+
+            // Attempt 1: fails, will be retried (ExecutionIgnored)
+            queues.enqueue(new SceneStarts(sceneId, details, t0));
+            queues.enqueue(new SceneTagged(sceneId, new ArbitraryTag('retried'), t0));
+            const act1 = CorrelationId.create();
+            const actDetails1 = new ActivityDetails(new Name('Alice ensures that 0 does equal 1'), new FileSystemLocation(Path.from('spec/failing.spec.ts'), 7, 1));
+            queues.enqueue(new InteractionStarts(sceneId, act1, actDetails1, t0));
+            queues.enqueue(new InteractionFinished(sceneId, act1, actDetails1, new ExecutionIgnored(new AssertionError('Expected 0 to equal 1')), t1));
+            queues.enqueue(new SceneFinished(sceneId, details, new ExecutionIgnored(new AssertionError('Expected 0 to equal 1')), t2));
+
+            // Attempt 2: fails, will be retried (ExecutionIgnored)
+            queues.enqueue(new SceneStarts(sceneId, details, t3));
+            queues.enqueue(new SceneTagged(sceneId, new ArbitraryTag('retried'), t3));
+            const act2 = CorrelationId.create();
+            const actDetails2 = new ActivityDetails(new Name('Alice ensures that 0 does equal 1'), new FileSystemLocation(Path.from('spec/failing.spec.ts'), 7, 1));
+            queues.enqueue(new InteractionStarts(sceneId, act2, actDetails2, t3));
+            queues.enqueue(new InteractionFinished(sceneId, act2, actDetails2, new ExecutionIgnored(new AssertionError('Expected 0 to equal 1')), t4));
+            queues.enqueue(new SceneFinished(sceneId, details, new ExecutionIgnored(new AssertionError('Expected 0 to equal 1')), t5));
+
+            // Attempt 3: final failure (ExecutionFailedWithAssertionError)
+            queues.enqueue(new SceneStarts(sceneId, details, t6));
+            queues.enqueue(new SceneTagged(sceneId, new ArbitraryTag('retried'), t6));
+            const act3 = CorrelationId.create();
+            const actDetails3 = new ActivityDetails(new Name('Alice ensures that 0 does equal 1'), new FileSystemLocation(Path.from('spec/failing.spec.ts'), 7, 1));
+            queues.enqueue(new InteractionStarts(sceneId, act3, actDetails3, t6));
+            queues.enqueue(new InteractionFinished(sceneId, act3, actDetails3, new ExecutionFailedWithAssertionError(new AssertionError('Expected 0 to equal 1')), t7));
+            queues.enqueue(new SceneFinished(sceneId, details, new ExecutionFailedWithAssertionError(new AssertionError('Expected 0 to equal 1')), t8));
+
+            const runData = collector.collect({ queues, testRunStartedAt: '2024-01-01T00:00:00.000Z', testRunnerName: 'Playwright', testRunnerVersion: '1.50.0', artifactPaths: new Map(), systemContext });
+
+            expect(runData.scenes).toHaveLength(1);
+            const scene = runData.scenes[0];
+
+            // Final outcome is FAILURE
+            expect(scene.outcome.code).toBe(ExecutionFailedWithAssertionError.Code);
+            expect(scene.retries).toBe(2);
+            expect(scene.attempts).toHaveLength(3);
+
+            // All three attempts should be recorded as failures, not successes
+            expect(scene.attempts[0].outcome.code).not.toBe(ExecutionSuccessful.Code);
+            expect(scene.attempts[1].outcome.code).not.toBe(ExecutionSuccessful.Code);
+            expect(scene.attempts[2].outcome.code).toBe(ExecutionFailedWithAssertionError.Code);
         });
 
         test('does not produce attempts for non-retried scenarios', () => {

--- a/packages/html-reporter/src/cli/HtmlReporterConfig.ts
+++ b/packages/html-reporter/src/cli/HtmlReporterConfig.ts
@@ -113,7 +113,10 @@ export interface HtmlReporterConfig {
 
     /**
      * Custom title displayed in the report header.
-     * When not specified, the report uses the project name.
+     *
+     * Fallback order when not specified:
+     * 1. {@link projectName} (if set, or auto-detected from `package.json`)
+     * 2. Test runner name (e.g. "Playwright", "Mocha")
      */
     title?: string;
 
@@ -133,7 +136,9 @@ export interface HtmlReporterConfig {
     consistencyWindow?: number;
 
     /**
-     * Custom project name displayed in the report.
+     * Custom project name displayed in the report's System Context view,
+     * and used as the report {@link title} when `title` is not set.
+     *
      * When not specified, the name is read from the closest `package.json`.
      */
     projectName?: string;

--- a/packages/html-reporter/src/cli/aggregation/ReportAggregator.ts
+++ b/packages/html-reporter/src/cli/aggregation/ReportAggregator.ts
@@ -149,7 +149,7 @@ export abstract class ReportAggregator {
         const testRunnerName = latestRun.testRunner?.name || 'unknown';
 
         return {
-            title: this.config.title || testRunnerName,
+            title: this.config.title || latestRun.systemContext?.projectName || testRunnerName,
             totalScenarios: latestRun.scenes.length,
             outcomes: latestRun.outcomes,
             duration,

--- a/packages/html-reporter/src/cli/collection/outcomeSerialisers.ts
+++ b/packages/html-reporter/src/cli/collection/outcomeSerialisers.ts
@@ -3,6 +3,7 @@ import {
     ExecutionCompromised,
     ExecutionFailedWithAssertionError,
     ExecutionFailedWithError,
+    ExecutionIgnored,
     ExecutionSkipped,
     ExecutionSuccessful,
     ImplementationPending
@@ -54,6 +55,7 @@ const outcomeCodeMap = [
     { type: ExecutionFailedWithAssertionError, code: ExecutionFailedWithAssertionError.Code },
     { type: ExecutionFailedWithError, code: ExecutionFailedWithError.Code },
     { type: ExecutionCompromised, code: ExecutionCompromised.Code },
+    { type: ExecutionIgnored, code: ExecutionIgnored.Code },
     { type: ExecutionSkipped, code: ExecutionSkipped.Code },
     { type: ImplementationPending, code: ImplementationPending.Code },
 ] as const;

--- a/packages/html-reporter/src/cli/model/outcomes.ts
+++ b/packages/html-reporter/src/cli/model/outcomes.ts
@@ -2,6 +2,7 @@ import {
     ExecutionCompromised,
     ExecutionFailedWithAssertionError,
     ExecutionFailedWithError,
+    ExecutionIgnored,
     ExecutionSkipped,
     ExecutionSuccessful,
     ImplementationPending,
@@ -15,6 +16,7 @@ export const VALID_OUTCOME_CODES = [
     ExecutionFailedWithAssertionError.Code,
     ExecutionFailedWithError.Code,
     ExecutionCompromised.Code,
+    ExecutionIgnored.Code,
     ImplementationPending.Code,
     ExecutionSkipped.Code,
 ] as const;
@@ -42,6 +44,7 @@ export const OUTCOME_CODE_DISPLAY_STRINGS: Record<number, string> = {
     [ExecutionFailedWithAssertionError.Code]: 'FAILURE',
     [ExecutionFailedWithError.Code]: 'ERROR',
     [ExecutionCompromised.Code]: 'COMPROMISED',
+    [ExecutionIgnored.Code]: 'FAILURE',
     [ImplementationPending.Code]: 'PENDING',
     [ExecutionSkipped.Code]: 'SKIPPED',
 };


### PR DESCRIPTION
Two bug fixes for the HTML Reporter.
  
### 1. Retry attempts incorrectly shown as "passed"
  
When a test fails across all retries, attempts 1 and 2 were displayed as "passed" in the Retry Tabs. `ExecutionIgnored` (Playwright Test's outcome for "failed, will retry") was missing from `outcomeCodeMap`, causing it to fall through to `ExecutionSuccessful`. Fixed by adding it and mapping to `'FAILURE'`.
  
### 2. Report title not falling back to project name
  
Title skipped `projectName` and fell directly to the test runner name (e.g., "Playwright"). Fixed to follow: `title` → `projectName` (from `package.json`) → test runner name. Updated JSDoc and README.