### PR TITLE
 feat(web): fluent PageElement chaining and identity filtering

### DIFF
--- a/.kiro/specs/fluent-page-element-chaining.md
+++ b/.kiro/specs/fluent-page-element-chaining.md
@@ -1,6 +1,32 @@
 # Fluent Page Element Chaining and Identity Filtering
 
-## Status: Design
+## Status: Implementation Complete — Pending Review
+
+## Decisions Made
+
+1. **Naming:** `.element()` / `.elements()` — mirrors `PageElement` / `PageElements` class names.
+2. **Return type of `.elements()`:** `MetaList<PageElement>` via proxy forwarding (enables full PEQL).
+3. **Single-arg `.where()` scope:** Accepts any `Expectation<Item_Type>` — works for non-web Lists too.
+4. **InteractionObject deprecation:** Not now. `child()` / `children()` remain as slightly shorter aliases; InteractionObject provides other value (mobile branching, Optional interface, composition patterns).
+
+## What's Implemented
+
+- Single-arg `.where(expectation)` on `List`, `ArrayList`, `MetaList` (core)
+- `Locator.createChildLocator(selector)` on all 4 adapters
+- `PageElement.element(selector)` / `.elements(selector)` on all 4 adapters
+- `ChainedElementQuestion` / `ChainedElementsLocator` for `.of()` composability
+- `PageElement.located()` wired with `metaQuestionBody` for proper `.of()` support
+- 10 integration tests (playwright-web), 5 unit tests (core)
+- All 561 integration tests passing
+
+## What Remains
+
+- Integration tests for single-arg `.where(isVisible())` in a browser (needs visible/hidden elements in fixture)
+- Deep chain test: `element → elements → where → first → elements → first`
+- `Wait.until()` integration test with chained elements
+- WebdriverIO integration test verification
+- PEQL handbook page update
+- API docs for new methods
 
 ## Problem
 
@@ -355,20 +381,6 @@ The interaction object handbook page should be written **after** this ships, so 
 7. **`@serenity-js/webdriverio`** — Same for WebdriverIO
 8. **Tests** — unit + integration tests per the plan above
 9. **Documentation** — update PEQL handbook page, add examples
-
-## Open Questions
-
-1. **Naming: `.element()` / `.elements()` vs `.child()` / `.children()` vs `.locate()` / `.locateAll()`?**
-   Recommendation: `.element()` / `.elements()` — mirrors the class names `PageElement` / `PageElements`, reads naturally, avoids DOM-specific terminology.
-
-2. **Should `.elements()` on `QuestionAdapter<PageElement>` return `MetaList` or `PageElements`?**
-   It should return whatever type enables full PEQL (`.where()`, `.first()`, `.eachMappedTo()`). `MetaList<PageElement>` is the existing type for this.
-
-3. **Should the single-arg `.where()` accept any `Expectation<Item_Type>` or only web-specific ones?**
-   Any `Expectation<Item_Type>` — this makes it useful for non-web Lists too (e.g., filtering API response arrays).
-
-4. **Should `InteractionObject.child()` / `children()` be deprecated in favour of `this.rootElement.element()` / `.elements()`?**
-   Not immediately. They're slightly shorter and the base class provides other value. Revisit after shipping.
 
 ## Future Considerations
 

--- a/.kiro/specs/fluent-page-element-chaining.md
+++ b/.kiro/specs/fluent-page-element-chaining.md
@@ -1,0 +1,377 @@
+# Fluent Page Element Chaining and Identity Filtering
+
+## Status: Design
+
+## Problem
+
+PEQL's current API for scoping elements within a parent requires constructing elements separately and composing them with `.of()`:
+
+```typescript
+// Current: verbose, non-obvious to new users
+const item = PageElement.located(By.css('.item')).of(list);
+const items = PageElements.located(By.css('.item')).of(list);
+const label = PageElement.located(By.css('.label')).of(
+    PageElements.located(By.css('.item')).of(list)
+        .where(Text, includes('cheese'))
+        .first()
+);
+```
+
+Additionally, filtering a collection by an element's **own** properties (visibility, presence, enabled state) requires understanding MetaQuestions — there's no way to express "keep only visible elements" without a two-argument `.where()`:
+
+```typescript
+// Current: no good way to filter by element's own state
+items.where(???, isVisible())  // what goes in the first arg?
+```
+
+These DX gaps surface as:
+- Discussion: "Why are page elements questions?" (user confusion about the API model)
+- Issue #1339: Complex `.where().where().first()` chains that are hard to express
+- The need for `InteractionObject` base class just to get `child()`/`children()` convenience
+
+## Design Goals
+
+1. **Fluent chaining** — `parent.element(selector)` and `parent.elements(selector)` as natural child access
+2. **Full composability** — `.of()` rescopes the entire chain; results work with `.where()`, `Text.of()`, `Click.on()`
+3. **Identity filtering** — single-arg `.where(expectation)` applies the expectation to each element directly
+4. **Backwards compatible** — additive API; existing code unchanged
+5. **Integration-tool agnostic** — works identically across Playwright, WebdriverIO, and future adapters
+
+## Proposed API
+
+### Fluent Element Access
+
+```typescript
+import { By, PageElement, PageElements } from '@serenity-js/web';
+
+const list = PageElement.located(By.css('.todo-list')).describedAs('todo list');
+
+// Single child element — returns MetaQuestionAdapter<PageElement, PageElement>
+list.element(By.css('.header'))
+
+// Collection of children — returns MetaList<PageElement> (full PEQL)
+list.elements(By.css('.item'))
+
+// Chained drilling
+list.element(By.css('.item')).element(By.css('.label'))
+
+// Alternating single/collection
+list.elements(By.css('.item'))
+    .where(Text, includes('cheese'))
+    .first()
+    .element(By.css('.delete-button'))
+```
+
+### Single-Arg `.where()` for Identity Filtering
+
+```typescript
+import { isVisible, isEnabled, isPresent } from '@serenity-js/web';
+import { includes } from '@serenity-js/assertions';
+
+// Filter by element's own visibility
+list.elements(By.css('.item')).where(isVisible()).first()
+
+// Filter by element's own presence
+list.elements(By.css('.item')).where(isPresent()).first()
+
+// Combine identity and projection filters
+list.elements(By.css('.item'))
+    .where(isVisible())                    // element itself must be visible
+    .where(Text, includes('cheese'))       // its text must include 'cheese'
+    .first()
+```
+
+### Composability with `.of()`
+
+```typescript
+// Define a reusable relative locator (no parent bound yet)
+const itemLabel = PageElement.located(By.css('.item'))
+    .element(By.css('.label'));
+
+// Compose with different parents at test time
+const sidebar = PageElement.located(By.css('.sidebar'));
+const main = PageElement.located(By.css('.main'));
+
+Text.of(itemLabel.of(sidebar))   // finds .item within .sidebar, then .label within that
+Text.of(itemLabel.of(main))      // same chain, different root
+```
+
+### Deep Chains
+
+```typescript
+// The full expressiveness: drill, fan out, filter, pick, drill again
+PageElement.located(By.css('.app'))
+    .element(By.css('.sidebar'))
+    .elements(By.css('.menu-section'))
+    .where(isVisible())
+    .first()
+    .elements(By.css('.menu-item'))
+    .where(Text, includes('Settings'))
+    .first()
+```
+
+## Type Signatures
+
+### On `PageElement` (instance methods)
+
+```typescript
+abstract class PageElement<NET> {
+    // Existing:
+    abstract of(parentElement: PageElement<NET>): PageElement<NET>;
+
+    // New:
+    abstract element(selector: Selector): PageElement<NET>;
+    abstract elements(selector: Selector): Array<PageElement<NET>>;
+}
+```
+
+### On `MetaQuestionAdapter<PageElement, PageElement>` (via proxy forwarding)
+
+When called on a `QuestionAdapter<PageElement>` (the proxy), the proxy resolves the parent element and calls the instance method. The result is wrapped in a new Question:
+
+```typescript
+// These are available automatically through the proxy — no explicit definition needed:
+parent.element(selector)   // → QuestionAdapter<PageElement>  (proxy-wrapped)
+parent.elements(selector)  // → QuestionAdapter<Array<PageElement>>  → needs MetaList wrapping
+```
+
+### On `List` (new overload)
+
+```typescript
+abstract class List<Item_Type> {
+    // Existing:
+    abstract where<Answer_Type>(
+        question: MetaQuestion<Item_Type, Question<Promise<Answer_Type> | Answer_Type>>,
+        expectation: Expectation<Answer_Type>
+    ): List<Item_Type>;
+
+    // New overload — identity filtering:
+    abstract where(
+        expectation: Expectation<Item_Type>
+    ): List<Item_Type>;
+}
+```
+
+## Architecture
+
+### Component 1: `PageElement.element()` and `PageElement.elements()`
+
+**Instance methods on the abstract `PageElement` class.** Each concrete implementation (Playwright, WebdriverIO) implements them by creating a child locator scoped within the current element.
+
+```typescript
+// PlaywrightPageElement:
+element(selector: Selector): PageElement<playwright.Locator> {
+    const childLocator = this.locator.createChildLocator(selector);
+    return new PlaywrightPageElement(childLocator);
+}
+
+elements(selector: Selector): Array<PageElement<playwright.Locator>> {
+    // Delegates to locator to find all matching children
+}
+```
+
+**Requires:** New abstract method `createChildLocator(selector: Selector): Locator` on `Locator`.
+
+### Component 2: Proxy Forwarding (zero changes to `@serenity-js/core`)
+
+The existing `QuestionAdapter` proxy already forwards any method call to the resolved instance. Since `PageElement` gains `.element()` and `.elements()`, they're immediately available on any `QuestionAdapter<PageElement>`.
+
+However, the proxy wraps the return in a plain `QuestionAdapter` — not a `MetaQuestionAdapter`. This means the result of `.element()` via the proxy **won't have a composable `.of()`** without additional work.
+
+### Component 3: `ChainedPageElementLocator` (preserves `.of()` composability)
+
+For `.element()` and `.elements()` to remain composable with `.of()`, we need explicit Question-level classes that **remember the chain** and replay it when `.of()` is called:
+
+```typescript
+/**
+ * @package
+ */
+class ChainedElementQuestion<NET>
+    extends Question<Promise<PageElement<NET>>>
+    implements ChainableMetaQuestion<PageElement<NET>, Question<Promise<PageElement<NET>>>>
+{
+    constructor(
+        private readonly parent: Answerable<PageElement<NET>> & ChainableMetaQuestion<PageElement<NET>, any>,
+        private readonly selector: Answerable<Selector>,
+    ) {
+        super(the`${parent}.element(${selector})`);
+    }
+
+    of(context: Answerable<PageElement<NET>>): ChainedElementQuestion<NET> {
+        return new ChainedElementQuestion(
+            this.parent.of(context),   // rescope the parent
+            this.selector,
+        );
+    }
+
+    async answeredBy(actor: AnswersQuestions & UsesAbilities): Promise<PageElement<NET>> {
+        const parent = await actor.answer(this.parent);
+        const selector = await actor.answer(this.selector);
+        return parent.element(selector);
+    }
+
+    // Also needs .element() and .elements() to continue the chain
+    element(selector: Answerable<Selector>): ChainedElementQuestion<NET> {
+        return new ChainedElementQuestion(this, selector);
+    }
+
+    elements(selector: Answerable<Selector>): ChainedElementsQuestion<NET> {
+        return new ChainedElementsQuestion(this, selector);
+    }
+}
+```
+
+Similarly, `ChainedElementsQuestion` returns a `MetaList` and implements `ChainableMetaQuestion` so `.of()` propagates through the entire collection chain.
+
+### Component 4: Entry Points on `MetaQuestionAdapter<PageElement>`
+
+The `.element()` and `.elements()` methods need to be explicitly available on `PageElement.located()` results — not just through proxy forwarding (which loses `MetaQuestion` nature).
+
+**Option A:** Add `.element()` / `.elements()` as methods on a new `PageElementQuestion` class that `PageElement.located()` returns.
+
+**Option B:** Use the proxy `get` trap to detect calls to `.element()` / `.elements()` and return `ChainedElementQuestion` / `ChainedElementsQuestion` instead of generic proxy forwarding.
+
+**Option C:** Make `PageElement.located()` return an enriched wrapper that has these methods alongside the existing proxy.
+
+**Recommendation:** Option A — a dedicated class keeps the logic explicit and testable. The existing `MetaQuestionStatement` already demonstrates this pattern.
+
+### Component 5: Single-Arg `.where()` on `List`
+
+Add an overload to `List.where()` that accepts only an `Expectation<Item_Type>`:
+
+```typescript
+// In ArrayList and MetaList:
+where(expectation: Expectation<Item_Type>): List<Item_Type>
+where<AT>(question: MetaQuestion<Item_Type, Question<AT>>, expectation: Expectation<AT>): List<Item_Type>
+where(...args: any[]): List<Item_Type> {
+    if (args.length === 1) {
+        // Identity filtering: apply expectation to each item directly
+        return new ArrayList<Item_Type>(
+            new WhereIdentity(this.collection, args[0], this.toString())
+        );
+    }
+    // Existing two-arg form
+    return new ArrayList<Item_Type>(
+        new Where(this.collection, args[0], args[1], this.toString())
+    );
+}
+```
+
+`WhereIdentity` filters by passing each item directly to the expectation (no projection step).
+
+### Component 6: `Locator.createChildLocator(selector)` (per integration tool)
+
+Each concrete `Locator` needs a method to create a child locator scoped within itself:
+
+```typescript
+// PlaywrightLocator:
+createChildLocator(selector: Selector): PlaywrightLocator {
+    return new PlaywrightLocator(this, selector);
+    // 'this' becomes the parent RootLocator
+}
+```
+
+This is structurally identical to what happens when you call `locator.of(parentLocator)` — just initiated from the parent side instead of the child side.
+
+## Packages Affected
+
+| Package | Changes | Risk |
+|---------|---------|------|
+| `@serenity-js/core` | New `.where(expectation)` overload on `List`, `ArrayList`, `MetaList` | Low — additive overload |
+| `@serenity-js/web` | New `element()`/`elements()` on `PageElement`; `ChainedElementQuestion`; `Locator.createChildLocator()` | Medium — new abstract methods require impl in each adapter |
+| `@serenity-js/playwright` | Implement `element()`, `elements()`, `createChildLocator()` on `PlaywrightPageElement`/`PlaywrightLocator` | Low — delegates to existing Playwright locator scoping |
+| `@serenity-js/webdriverio` | Same as Playwright | Low |
+| `@serenity-js/protractor` | Same (if still maintained) | Low |
+
+## Backwards Compatibility
+
+- **Fully additive** — no existing method signatures change
+- **No behaviour changes** — existing `.where(question, expectation)` unchanged
+- **No breaking types** — new abstract methods on `PageElement` and `Locator` require implementation in concrete subclasses, but these are `@package`-internal (users don't subclass `PageElement`)
+- **Deprecation:** None — `.of()` and `PageElement.located(x).of(y)` remain valid and equivalent
+
+## Relation to Existing Work
+
+### InteractionObject
+
+`InteractionObject.child()` / `children()` become thin aliases for `this.rootElement.element()` / `this.rootElement.elements()`. The base class retains value for:
+- Grouping Questions + Tasks into a cohesive domain API
+- Mobile branching (`this.mobile` flag)
+- `Optional` interface (view-level presence)
+- Documentation pattern (composition hierarchy)
+
+### Issue #1339
+
+Single-arg `.where(isPresent())` / `.where(isVisible())` lets users pre-filter collections by element state without understanding MetaQuestions. Combined with `Wait.until()`, this reduces the "immediate throw on empty list" pattern that confused the reporter.
+
+### Handbook / Documentation
+
+The interaction object handbook page should be written **after** this ships, so it can position `InteractionObject` as the "when you outgrow ad-hoc chains" pattern rather than "the only way to scope elements."
+
+## Test Plan
+
+### Unit Tests (`packages/web/spec/`)
+
+**`PageElement.element()`:**
+1. Locates a child element within the parent
+2. Chains multiple `.element()` calls (grandchild)
+3. Works with `Text.of()`, `Attribute.called().of()`
+4. `.of()` rescopes the entire chain to a new parent
+5. Throws descriptively when the parent doesn't exist
+6. Accepts `Answerable<Selector>` for runtime resolution
+
+**`PageElement.elements()`:**
+7. Returns a collection scoped within the parent
+8. Supports `.where()`, `.first()`, `.last()`, `.count()`
+9. Supports `.eachMappedTo(Text)`
+10. `.of()` rescopes the entire collection chain
+11. Chaining `.first().element()` re-enters single-element mode
+12. Chaining `.first().elements()` re-enters collection mode
+
+**Single-arg `.where()`:**
+13. Filters by `isVisible()` — keeps only visible elements
+14. Filters by `isPresent()` — keeps only present elements
+15. Filters by `isEnabled()` — keeps only enabled elements
+16. Composes with two-arg `.where()` — both forms in one chain
+17. Returns empty list (doesn't throw) when no elements match
+18. Works with `Wait.until(collection.where(isVisible()).first(), isPresent())`
+
+### Integration Tests (`integration/playwright-web/` or `integration/web-specs/`)
+
+19. Full chain resolves correctly in a real browser
+20. `.of()` correctly rescopes across different parent elements
+21. Single-arg `.where(isVisible())` filters hidden elements
+22. Deep chain (element → elements → where → first → elements → first) resolves
+23. Chain works with `Wait.until()` for dynamic content
+
+## Implementation Sequence
+
+1. **`@serenity-js/core`** — Add single-arg `.where()` overload to `List`, `ArrayList`, `MetaList` + `WhereIdentity` filter class
+2. **`@serenity-js/web`** — Add `Locator.createChildLocator(selector)` abstract method
+3. **`@serenity-js/web`** — Add `PageElement.element(selector)` and `PageElement.elements(selector)` abstract methods
+4. **`@serenity-js/web`** — Implement `ChainedElementQuestion` and `ChainedElementsQuestion` classes
+5. **`@serenity-js/web`** — Wire `.element()` / `.elements()` on `PageElement.located()` to return chained questions
+6. **`@serenity-js/playwright`** — Implement `createChildLocator`, `element()`, `elements()` on `PlaywrightLocator` / `PlaywrightPageElement`
+7. **`@serenity-js/webdriverio`** — Same for WebdriverIO
+8. **Tests** — unit + integration tests per the plan above
+9. **Documentation** — update PEQL handbook page, add examples
+
+## Open Questions
+
+1. **Naming: `.element()` / `.elements()` vs `.child()` / `.children()` vs `.locate()` / `.locateAll()`?**
+   Recommendation: `.element()` / `.elements()` — mirrors the class names `PageElement` / `PageElements`, reads naturally, avoids DOM-specific terminology.
+
+2. **Should `.elements()` on `QuestionAdapter<PageElement>` return `MetaList` or `PageElements`?**
+   It should return whatever type enables full PEQL (`.where()`, `.first()`, `.eachMappedTo()`). `MetaList<PageElement>` is the existing type for this.
+
+3. **Should the single-arg `.where()` accept any `Expectation<Item_Type>` or only web-specific ones?**
+   Any `Expectation<Item_Type>` — this makes it useful for non-web Lists too (e.g., filtering API response arrays).
+
+4. **Should `InteractionObject.child()` / `children()` be deprecated in favour of `this.rootElement.element()` / `.elements()`?**
+   Not immediately. They're slightly shorter and the base class provides other value. Revisit after shipping.
+
+## Future Considerations
+
+- **`.text()` as MetaQuestion on chains** — `parent.element(selector).text()` could return a MetaQuestion usable in `.where()` (eliminates `Text.of(PageElement.located(selector))` pattern)
+- **`.attribute(name)` as MetaQuestion** — same pattern
+- **Playwright `locator()` parity** — Playwright's `locator.locator(selector)` is the native equivalent; our implementation can delegate directly to it

--- a/.kiro/steering/development-workflow.md
+++ b/.kiro/steering/development-workflow.md
@@ -188,6 +188,14 @@ See the Pre-Commit Checklist below for the full list.
 - Never fabricate observations or claim to have seen something you inferred
 - **Never project certainty when you have doubts.** If you are unsure whether something will work — especially irreversible operations like publishing, deploying, or deleting — say "I'm not certain" upfront. Phrasing like "that's fine" or "this should work" when you're guessing can lead to costly mistakes. State what you know, what you're inferring, and what you cannot verify.
 
+### Test Failures Are Your Responsibility
+
+- **Never dismiss test failures as "pre-existing."** The main branch CI is always green. If tests fail after your changes, your changes are the prime suspect.
+- **Never check out `main` to "prove" failures exist independently.** Compiled output bleeds across branches in a monorepo — local `main` runs are unreliable. CI is the source of truth.
+- **Investigate before classifying.** Read the error → trace it to the assertion → understand what changed → fix it. Do not glance at the error, decide it's unrelated, and move on.
+- **Never push with failing tests.** The push comes after 0 failures. If tests fail, fix them first. If a failure is genuinely unrelated to your changes, explain exactly why with evidence (the specific assertion, why your change cannot affect it, what does affect it).
+- **Never report work as complete while tests fail.** "558 passing, 3 pre-existing failures" is not an acceptable status report. The only acceptable status is "all tests pass" or "N tests fail because [specific traced cause], fixing now."
+
 ## Clarification Policy
 
 If requirements are unclear, ask before writing tests. One clear question is better than a wrong assumption.

--- a/.kiro/steering/lessons-learned.md
+++ b/.kiro/steering/lessons-learned.md
@@ -310,6 +310,14 @@ Don't duplicate content between them. `resources` in the agent definition provid
 
 ---
 
+## Serenity/JS Core — Implementation Gotchas
+
+### Adding `metaQuestionBody` to `Question.about()` changes the proxy inspect output
+
+When you pass a third argument (metaQuestionBody) to `Question.about()`, the underlying statement becomes a `MetaQuestionStatement` instead of a `QuestionStatement`. This changes `util.inspect` output of the proxy from `Proxy<QuestionStatement>` to `Proxy<MetaQuestionStatement>`. Any integration test that asserts on error messages containing the inspect representation will fail. Search for `Proxy<QuestionStatement>` in `integration/web-specs/spec/expectations/` when making such changes.
+
+---
+
 ## Serenity/JS Templates — CI Gotchas
 
 ### `@wdio/xvfb` auto-detection breaks IPC in Docker containers

--- a/integration/web-specs/spec/expectations/isActive.spec.ts
+++ b/integration/web-specs/spec/expectations/isActive.spec.ts
@@ -72,7 +72,7 @@ describe('isActive', function () {
                 | Expectation: isPresent\\(\\)
                 |
                 | Expected boolean:\\s+true
-                | Received Proxy<QuestionStatement>
+                | Received Proxy<MetaQuestionStatement>
                 | 
                 | [A-Za-z]+PageElement {
                 |   locator: [A-Za-z]+Locator {

--- a/integration/web-specs/spec/expectations/isPresent.spec.ts
+++ b/integration/web-specs/spec/expectations/isPresent.spec.ts
@@ -35,7 +35,7 @@ describe('isPresent', function () {
             | Expectation: isPresent\\(\\) 
             |
             | Expected boolean:\\s+true
-            | Received Proxy<QuestionStatement>
+            | Received Proxy<MetaQuestionStatement>
             |
             | [A-Za-z]+PageElement {
             |   locator: [A-Za-z]+Locator {
@@ -56,7 +56,7 @@ describe('isPresent', function () {
             | Expectation: isPresent\\(\\) 
             |
             | Expected boolean:\\s+true
-            | Received Proxy<QuestionStatement>
+            | Received Proxy<MetaQuestionStatement>
             |
             | [A-Za-z]+PageElement {
             |   locator: [A-Za-z]+Locator {

--- a/integration/web-specs/spec/screenplay/models/PageElement.chaining.spec.ts
+++ b/integration/web-specs/spec/screenplay/models/PageElement.chaining.spec.ts
@@ -1,6 +1,6 @@
 import 'mocha';
 
-import { Ensure, contain, equals, includes } from '@serenity-js/assertions';
+import { Ensure, equals, includes } from '@serenity-js/assertions';
 import { actorCalled } from '@serenity-js/core';
 import { By, Navigate, PageElement, Text } from '@serenity-js/web';
 

--- a/integration/web-specs/spec/screenplay/models/PageElement.chaining.spec.ts
+++ b/integration/web-specs/spec/screenplay/models/PageElement.chaining.spec.ts
@@ -1,0 +1,151 @@
+import 'mocha';
+
+import { Ensure, contain, equals, includes } from '@serenity-js/assertions';
+import { actorCalled } from '@serenity-js/core';
+import { By, Navigate, PageElement, Text } from '@serenity-js/web';
+
+/** @test {PageElement} */
+describe('PageElement', () => {
+
+    beforeEach(() =>
+        actorCalled('Peggy').attemptsTo(
+            Navigate.to('/screenplay/models/page-elements/locator_patterns.html')
+        ));
+
+    describe('when using fluent element chaining', () => {
+
+        describe('.element(selector)', () => {
+
+            it('resolves a child element within a parent', () =>
+                actorCalled('Peggy').attemptsTo(
+                    Ensure.that(
+                        Text.of(
+                            PageElement.located(By.css('[data-test-id="child-of-parent-locator-pattern"]'))
+                                .element(By.css('[data-test-id="parent-1"]'))
+                                .element(By.css('.child'))
+                        ),
+                        equals('child 1.1'),
+                    ),
+                ));
+
+            it('resolves a direct child within a parent section', () =>
+                actorCalled('Peggy').attemptsTo(
+                    Ensure.that(
+                        Text.of(
+                            PageElement.located(By.css('[data-test-id="child-of-parent-locator-pattern"]'))
+                                .element(By.css('[data-test-id="parent-2"] .child'))
+                        ),
+                        equals('child 2.1'),
+                    ),
+                ));
+
+            it('supports multi-level chaining: parent.element(child).element(grandchild)', () =>
+                actorCalled('Peggy').attemptsTo(
+                    Ensure.that(
+                        Text.of(
+                            PageElement.located(By.css('[data-test-id="child-of-parent-locator-pattern"]'))
+                                .element(By.css('[data-test-id="parent-2"]'))
+                                .element(By.css('.child'))
+                        ),
+                        equals('child 2.1'),
+                    ),
+                ));
+        });
+
+        describe('.elements(selector)', () => {
+
+            it('resolves all children within a parent', () =>
+                actorCalled('Peggy').attemptsTo(
+                    Ensure.that(
+                        Text.ofAll(
+                            PageElement.located(By.css('[data-test-id="filter-locator-pattern"] [data-test-id="parent-2"]'))
+                                .elements(By.css('.child'))
+                        ),
+                        equals(['tea', 'coffee']),
+                    ),
+                ));
+
+            it('resolves all items within a nested container', () =>
+                actorCalled('Peggy').attemptsTo(
+                    Ensure.that(
+                        Text.ofAll(
+                            PageElement.located(By.css('[data-test-id="mapping-tabular-data-to-object"] .container'))
+                                .elements(By.css('.item .name'))
+                        ),
+                        equals(['apples', 'bananas']),
+                    ),
+                ));
+        });
+
+        describe('.of() rescoping with PageElement.located()', () => {
+
+            const child = () =>
+                PageElement.located(By.css('.child'));
+
+            const parent1 = () =>
+                PageElement.located(By.css('[data-test-id="parent-1"]'))
+                    .of(
+                        PageElement.located(By.css('[data-test-id="child-of-parent-locator-pattern"]'))
+                    );
+
+            const parent2 = () =>
+                PageElement.located(By.css('[data-test-id="parent-2"]'))
+                    .of(
+                        PageElement.located(By.css('[data-test-id="child-of-parent-locator-pattern"]'))
+                    );
+
+            it('rescopes a located element using .of() to resolve within a parent', () =>
+                actorCalled('Peggy').attemptsTo(
+                    Ensure.that(
+                        Text.of(child().of(parent1())),
+                        equals('child 1.1'),
+                    ),
+                ));
+
+            it('rescopes to a different parent using .of()', () =>
+                actorCalled('Peggy').attemptsTo(
+                    Ensure.that(
+                        Text.of(child().of(parent2())),
+                        equals('child 2.1'),
+                    ),
+                ));
+        });
+
+        describe('integrating with Text.of() and Ensure.that()', () => {
+
+            it('extracts text from a deeply chained element', () =>
+                actorCalled('Peggy').attemptsTo(
+                    Ensure.that(
+                        Text.of(
+                            PageElement.located(By.css('[data-test-id="child-of-parent-locator-pattern"]'))
+                                .element(By.css('[data-test-id="parent-1"]'))
+                                .element(By.css('[data-test-id="child-1-1"]'))
+                        ),
+                        equals('child 1.1'),
+                    ),
+                ));
+
+            it('extracts text from a child within a filter-pattern section', () =>
+                actorCalled('Peggy').attemptsTo(
+                    Ensure.that(
+                        Text.of(
+                            PageElement.located(By.css('[data-test-id="filter-locator-pattern"] [data-test-id="parent-1"]'))
+                                .element(By.css('[data-test-id="child-1-1"]'))
+                        ),
+                        equals('tea'),
+                    ),
+                ));
+
+            it('verifies text content includes a substring', () =>
+                actorCalled('Peggy').attemptsTo(
+                    Ensure.that(
+                        Text.of(
+                            PageElement.located(By.css('[data-test-id="child-of-parent-locator-pattern"]'))
+                                .element(By.css('[data-test-id="parent-1"]'))
+                        ),
+                        includes('child 1.1'),
+                    ),
+                ));
+        });
+    });
+});

--- a/packages/core/spec/screenplay/questions/List.spec.ts
+++ b/packages/core/spec/screenplay/questions/List.spec.ts
@@ -191,6 +191,75 @@ describe('List', () => {
         });
     });
 
+    describe('when filtering with a single-arg .where(expectation)', () => {
+
+        it('returns only those items that match the expectation directly', async () => {
+            const items = [ 1, 2, 3, 4, 5 ];
+
+            const list = List.of(items);
+
+            const result = await list
+                .where(isGreaterThan(2))
+                .answeredBy(Fiona);
+
+            expect(result).to.deep.equal([ 3, 4, 5 ]);
+        });
+
+        it('composes with the two-arg .where() form', async () => {
+            const items = [ 1, 2, 3, 4, 5 ];
+
+            const list = List.of(items);
+
+            const result = await list
+                .where(isGreaterThan(2))
+                .where(Value, isLessThan(5))
+                .answeredBy(Fiona);
+
+            expect(result).to.deep.equal([ 3, 4 ]);
+        });
+
+        it('returns an empty list when no items match', async () => {
+            const items = [ 1, 2, 3 ];
+
+            const list = List.of(items);
+
+            const result = await list
+                .where(isGreaterThan(10))
+                .answeredBy(Fiona);
+
+            expect(result).to.deep.equal([]);
+        });
+
+        it('describes the filter applied', () => {
+            const items = [ 1, 2, 3, 4, 5 ];
+
+            const list = List.of(items);
+
+            const result = list
+                .where(isGreaterThan(2))
+                .first();
+
+            expect(result.toString()).to.equal(
+                'the first of [ 1, 2, 3, 4, 5 ] where it does have value greater than 2'
+            );
+        });
+
+        it('describes multiple single-arg filters', () => {
+            const items = [ 1, 2, 3, 4, 5 ];
+
+            const list = List.of(items);
+
+            const result = list
+                .where(isGreaterThan(2))
+                .where(isLessThan(5))
+                .first();
+
+            expect(result.toString()).to.equal(
+                'the first of [ 1, 2, 3, 4, 5 ] where it does have value greater than 2 and it does have value less than 5'
+            );
+        });
+    });
+
     describe('when mapping items of a collection', () => {
         const accounts: Account[] = [
             { id: 1, name: 'Alice' },
@@ -348,7 +417,7 @@ describe('List', () => {
             const location = activity.instantiationLocation();
 
             expect(location.path.basename()).to.equal('List.spec.ts');
-            expect(location.line).to.equal(347);
+            expect(location.line).to.equal(416);
             expect(location.column).to.equal(18);
         });
     });

--- a/packages/core/src/screenplay/questions/List.ts
+++ b/packages/core/src/screenplay/questions/List.ts
@@ -41,6 +41,10 @@ export abstract class List<Item_Type> extends Question<Promise<Array<Item_Type>>
         question: MetaQuestion<Item_Type, Question<Promise<Mapped_Item_Type> | Mapped_Item_Type>>
     ): List<Mapped_Item_Type>;
 
+    abstract where(
+        expectation: Expectation<Item_Type>
+    ): List<Item_Type>;
+
     abstract where<Answer_Type>(
         question: MetaQuestion<Item_Type, Question<Promise<Answer_Type> | Answer_Type>>,
         expectation: Expectation<Answer_Type>
@@ -98,10 +102,16 @@ class ArrayList<Item_Type> extends List<Item_Type> {
         );
     }
 
-    override where<Answer_Type>(
-        question: MetaQuestion<Item_Type, Question<Promise<Answer_Type> | Answer_Type>>,
-        expectation: Expectation<Answer_Type>
-    ): List<Item_Type> {
+    override where(expectation: Expectation<Item_Type>): List<Item_Type>;
+    override where<Answer_Type>(question: MetaQuestion<Item_Type, Question<Promise<Answer_Type> | Answer_Type>>, expectation: Expectation<Answer_Type>): List<Item_Type>;
+    override where<Answer_Type>(...args: unknown[]): List<Item_Type> {
+        if (args.length === 1) {
+            return new ArrayList<Item_Type>(
+                new WhereIdentity(this.collection, args[0] as Expectation<Item_Type>, this.toString())
+            ) as this;
+        }
+
+        const [question, expectation] = args as [MetaQuestion<Item_Type, Question<Promise<Answer_Type> | Answer_Type>>, Expectation<Answer_Type>];
         return new ArrayList<Item_Type>(
             new Where(this.collection, question, expectation, this.toString())
         ) as this;
@@ -207,10 +217,16 @@ export class MetaList<Supported_Context_Type, Item_Type>
         );
     }
 
-    override where<Answer_Type>(
-        question: MetaQuestion<Item_Type, Question<Promise<Answer_Type> | Answer_Type>>,
-        expectation: Expectation<Answer_Type>
-    ): MetaList<Supported_Context_Type, Item_Type> {
+    override where(expectation: Expectation<Item_Type>): MetaList<Supported_Context_Type, Item_Type>;
+    override where<Answer_Type>(question: MetaQuestion<Item_Type, Question<Promise<Answer_Type> | Answer_Type>>, expectation: Expectation<Answer_Type>): MetaList<Supported_Context_Type, Item_Type>;
+    override where<Answer_Type>(...args: unknown[]): MetaList<Supported_Context_Type, Item_Type> {
+        if (args.length === 1) {
+            return new MetaList<Supported_Context_Type, Item_Type>(
+                new MetaWhereIdentity(this.collection, args[0] as Expectation<Item_Type>, this.toString())
+            ) as this;
+        }
+
+        const [question, expectation] = args as [MetaQuestion<Item_Type, Question<Promise<Answer_Type> | Answer_Type>>, Expectation<Answer_Type>];
         return new MetaList<Supported_Context_Type, Item_Type>(
             new MetaWhere(this.collection, question, expectation, this.toString())
         ) as this;
@@ -324,6 +340,56 @@ class MetaWhere<Supported_Context_Type, Item_Type, Answer_Type>
         return new MetaWhere<Supported_Context_Type, Item_Type, Answer_Type>(
             (this.collection as Answerable<Array<Item_Type>> & ChainableMetaQuestion<Supported_Context_Type, Question<Promise<Array<Item_Type>>> | Question<Array<Item_Type>>>).of(context),
             this.question,
+            this.expectation,
+            this.toString()
+        );
+    }
+}
+
+/**
+ * @package
+ */
+class WhereIdentity<Item_Type>
+    extends Question<Promise<Array<Item_Type>>>
+{
+    constructor(
+        protected readonly collection: Answerable<Array<Item_Type>>,
+        protected readonly expectation: Expectation<Item_Type>,
+        originalSubject: string,
+    ) {
+        const prefix = collection instanceof Where || collection instanceof WhereIdentity
+            ? ' and'
+            : ' where';
+
+        super(originalSubject + prefix + d` it does ${ expectation }`);
+    }
+
+    async answeredBy(actor: AnswersQuestions & UsesAbilities): Promise<Array<Item_Type>> {
+        const collection = await actor.answer(this.collection);
+        const results: Item_Type[] = [];
+
+        for (const item of collection) {
+            const expectationOutcome = await actor.answer(this.expectation.isMetFor(item));
+
+            if (expectationOutcome instanceof ExpectationMet) {
+                results.push(item);
+            }
+        }
+
+        return results;
+    }
+}
+
+/**
+ * @package
+ */
+class MetaWhereIdentity<Supported_Context_Type, Item_Type>
+    extends WhereIdentity<Item_Type>
+    implements ChainableMetaQuestion<Supported_Context_Type, Question<Promise<Array<Item_Type>>> | Question<Array<Item_Type>>>
+{
+    of(context: Answerable<Supported_Context_Type>): MetaWhereIdentity<Supported_Context_Type, Item_Type> {
+        return new MetaWhereIdentity<Supported_Context_Type, Item_Type>(
+            (this.collection as Answerable<Array<Item_Type>> & ChainableMetaQuestion<Supported_Context_Type, Question<Promise<Array<Item_Type>>> | Question<Array<Item_Type>>>).of(context),
             this.expectation,
             this.toString()
         );

--- a/packages/playwright/src/screenplay/models/PlaywrightPageElement.ts
+++ b/packages/playwright/src/screenplay/models/PlaywrightPageElement.ts
@@ -1,5 +1,5 @@
 import { LogicError } from '@serenity-js/core';
-import type { SwitchableOrigin } from '@serenity-js/web';
+import type { Selector, SwitchableOrigin } from '@serenity-js/web';
 import { PageElement, SelectOption } from '@serenity-js/web';
 import * as scripts from '@serenity-js/web/scripts';
 import type * as playwright from 'playwright-core';
@@ -19,6 +19,15 @@ export class PlaywrightPageElement extends PageElement<playwright.Locator> {
 
     closestTo(child: PageElement<playwright.Locator>): PageElement<playwright.Locator> {
         return new PlaywrightPageElement(this.locator.closestTo(child.locator));
+    }
+
+    element(selector: Selector): PageElement<playwright.Locator> {
+        return new PlaywrightPageElement(this.locator.createChildLocator(selector));
+    }
+
+    async elements(selector: Selector): Promise<Array<PageElement<playwright.Locator>>> {
+        const childLocator = this.locator.createChildLocator(selector) as PlaywrightLocator;
+        return childLocator.allElements();
     }
 
     async enterValue(value: string | number | Array<string | number>): Promise<void> {

--- a/packages/playwright/src/screenplay/models/locators/PlaywrightLocator.ts
+++ b/packages/playwright/src/screenplay/models/locators/PlaywrightLocator.ts
@@ -105,6 +105,10 @@ export class PlaywrightLocator extends Locator<playwright.Locator, string> {
         return new PlaywrightLocator(this, child.selector);
     }
 
+    createChildLocator(selector: Selector): PlaywrightLocator {
+        return new PlaywrightLocator(this, selector);
+    }
+
     element(): PageElement<playwright.Locator> {
         return new PlaywrightPageElement(this);
     }

--- a/packages/protractor/src/screenplay/models/ProtractorPageElement.ts
+++ b/packages/protractor/src/screenplay/models/ProtractorPageElement.ts
@@ -1,5 +1,5 @@
 import { LogicError } from '@serenity-js/core';
-import type { SwitchableOrigin } from '@serenity-js/web';
+import type { Selector, SwitchableOrigin } from '@serenity-js/web';
 import { PageElement, SelectOption } from '@serenity-js/web';
 import * as scripts from '@serenity-js/web/scripts';
 import type { ElementFinder} from 'protractor';
@@ -21,6 +21,15 @@ export class ProtractorPageElement extends PageElement<ElementFinder> {
 
     closestTo(child: ProtractorPageElement): ProtractorPageElement {
         return new ProtractorPageElement(this.locator.closestTo(child.locator));
+    }
+
+    element(selector: Selector): PageElement<ElementFinder> {
+        return new ProtractorPageElement(this.locator.createChildLocator(selector));
+    }
+
+    async elements(selector: Selector): Promise<Array<PageElement<ElementFinder>>> {
+        const childLocator = this.locator.createChildLocator(selector) as ProtractorLocator;
+        return childLocator.allElements();
     }
 
     async clearValue(): Promise<void> {

--- a/packages/protractor/src/screenplay/models/locators/ProtractorLocator.ts
+++ b/packages/protractor/src/screenplay/models/locators/ProtractorLocator.ts
@@ -74,6 +74,10 @@ export class ProtractorLocator extends Locator<protractor.ElementFinder, protrac
         return new ProtractorLocator(this, child.selector, this.errorHandler);
     }
 
+    createChildLocator(selector: Selector): ProtractorLocator {
+        return new ProtractorLocator(this, selector, this.errorHandler);
+    }
+
     element(): PageElement<protractor.ElementFinder> {
         return new ProtractorPageElement(this);
     }

--- a/packages/web/src/screenplay/models/ChainedElementQuestion.ts
+++ b/packages/web/src/screenplay/models/ChainedElementQuestion.ts
@@ -1,0 +1,87 @@
+import type { Answerable, AnswersQuestions, ChainableMetaQuestion, UsesAbilities } from '@serenity-js/core';
+import { MetaList, Question, the } from '@serenity-js/core';
+
+import type { PageElement } from './PageElement.js';
+import { PageElementsLocator } from './PageElementsLocator.js';
+import type { Selector } from './selectors/index.js';
+
+/**
+ * Represents a single child element located within a parent element,
+ * preserving `.of()` composability through the chain.
+ *
+ * When `.of(context)` is called, the entire chain is rescoped:
+ * the parent is resolved relative to the new context.
+ *
+ * @package
+ */
+export class ChainedElementQuestion<Native_Element_Type = any>
+    extends Question<Promise<PageElement<Native_Element_Type>>>
+    implements ChainableMetaQuestion<PageElement<Native_Element_Type>, Question<Promise<PageElement<Native_Element_Type>>>>
+{
+    constructor(
+        private readonly parent: Answerable<PageElement<Native_Element_Type>> & ChainableMetaQuestion<PageElement<Native_Element_Type>, any>,
+        private readonly selector: Answerable<Selector>,
+    ) {
+        super(the`${ parent }.element(${ selector })`);
+    }
+
+    of(context: Answerable<PageElement<Native_Element_Type>>): ChainedElementQuestion<Native_Element_Type> {
+        return new ChainedElementQuestion<Native_Element_Type>(
+            this.parent.of(context),
+            this.selector,
+        );
+    }
+
+    async answeredBy(actor: AnswersQuestions & UsesAbilities): Promise<PageElement<Native_Element_Type>> {
+        const parentElement = await actor.answer(this.parent);
+        const selector = await actor.answer(this.selector);
+        return parentElement.element(selector);
+    }
+
+    /**
+     * Locates a single descendant element within this element.
+     */
+    element(selector: Answerable<Selector>): ChainedElementQuestion<Native_Element_Type> {
+        return new ChainedElementQuestion<Native_Element_Type>(this, selector);
+    }
+
+    /**
+     * Locates all descendant elements within this element, returning a PEQL collection.
+     */
+    elements(selector: Answerable<Selector>): MetaList<PageElement<Native_Element_Type>, PageElement<Native_Element_Type>> {
+        return new MetaList<PageElement<Native_Element_Type>, PageElement<Native_Element_Type>>(
+            new ChainedElementsLocator<Native_Element_Type>(this, selector),
+        );
+    }
+}
+
+/**
+ * Locates multiple child elements within a parent ChainedElementQuestion,
+ * preserving `.of()` composability.
+ *
+ * @package
+ */
+class ChainedElementsLocator<Native_Element_Type = any>
+    extends Question<Promise<Array<PageElement<Native_Element_Type>>>>
+    implements ChainableMetaQuestion<PageElement<Native_Element_Type>, Question<Promise<Array<PageElement<Native_Element_Type>>>>>
+{
+    constructor(
+        private readonly parent: ChainedElementQuestion<Native_Element_Type>,
+        private readonly selector: Answerable<Selector>,
+    ) {
+        super(the`${ parent }.elements(${ selector })`);
+    }
+
+    of(context: Answerable<PageElement<Native_Element_Type>>): ChainedElementsLocator<Native_Element_Type> {
+        return new ChainedElementsLocator<Native_Element_Type>(
+            this.parent.of(context),
+            this.selector,
+        );
+    }
+
+    async answeredBy(actor: AnswersQuestions & UsesAbilities): Promise<Array<PageElement<Native_Element_Type>>> {
+        const parentElement = await actor.answer(this.parent);
+        const selector = await actor.answer(this.selector);
+        return parentElement.elements(selector);
+    }
+}

--- a/packages/web/src/screenplay/models/ChainedElementQuestion.ts
+++ b/packages/web/src/screenplay/models/ChainedElementQuestion.ts
@@ -2,7 +2,6 @@ import type { Answerable, AnswersQuestions, ChainableMetaQuestion, UsesAbilities
 import { MetaList, Question, the } from '@serenity-js/core';
 
 import type { PageElement } from './PageElement.js';
-import { PageElementsLocator } from './PageElementsLocator.js';
 import type { Selector } from './selectors/index.js';
 
 /**

--- a/packages/web/src/screenplay/models/Locator.ts
+++ b/packages/web/src/screenplay/models/Locator.ts
@@ -51,6 +51,14 @@ export abstract class Locator<Native_Element_Type, Native_Selector_Type = any>
     abstract locate(child: Locator<Native_Element_Type>): Locator<Native_Element_Type>;
 
     /**
+     * Creates a child locator scoped within this locator's element, using the given selector.
+     *
+     * @param selector
+     *  The selector to locate the child element(s)
+     */
+    abstract createChildLocator(selector: Selector): Locator<Native_Element_Type>;
+
+    /**
      * Expresses [`ByCss`](https://serenity-js.org/api/web/class/ByCss/), [`ById`](https://serenity-js.org/api/web/class/ById/), or [`ByTagName`](https://serenity-js.org/api/web/class/ByTagName/) as a [`ByCss`](https://serenity-js.org/api/web/class/ByCss/) selector.
      *
      * @throws LogicError

--- a/packages/web/src/screenplay/models/PageElement.ts
+++ b/packages/web/src/screenplay/models/PageElement.ts
@@ -31,12 +31,20 @@ export abstract class PageElement<Native_Element_Type = any> implements Optional
     }
 
     static located<NET>(selector: Answerable<Selector>): MetaQuestionAdapter<PageElement<NET>, PageElement<NET>> {
-        return Question.about(the`page element located ${ selector }`, async actor => {
-            const bySelector  = await actor.answer(selector);
-            const currentPage = await BrowseTheWeb.as<BrowseTheWeb<NET>>(actor).currentPage();
+        return Question.about(the`page element located ${ selector }`,
+            async actor => {
+                const bySelector  = await actor.answer(selector);
+                const currentPage = await BrowseTheWeb.as<BrowseTheWeb<NET>>(actor).currentPage();
 
-            return currentPage.locate(bySelector);
-        });
+                return currentPage.locate(bySelector);
+            },
+            (parent: Answerable<PageElement<NET>>) =>
+                Question.about(the`page element located ${ selector } of ${ parent }`, async actor => {
+                    const bySelector = await actor.answer(selector);
+                    const parentElement = await actor.answer(parent);
+                    return parentElement.element(bySelector);
+                })
+        );
     }
 
     static of<NET>(

--- a/packages/web/src/screenplay/models/PageElement.ts
+++ b/packages/web/src/screenplay/models/PageElement.ts
@@ -97,6 +97,24 @@ export abstract class PageElement<Native_Element_Type = any> implements Optional
     abstract of(parentElement: PageElement<Native_Element_Type>): PageElement<Native_Element_Type>;
 
     /**
+     * Locates a single descendant element matching the given selector,
+     * scoped within this element.
+     *
+     * @param selector
+     *  The selector to locate the child element
+     */
+    abstract element(selector: Selector): PageElement<Native_Element_Type>;
+
+    /**
+     * Locates all descendant elements matching the given selector,
+     * scoped within this element.
+     *
+     * @param selector
+     *  The selector to locate the child elements
+     */
+    abstract elements(selector: Selector): Promise<Array<PageElement<Native_Element_Type>>>;
+
+    /**
      * Traverses the element and its parents, heading toward the document root,
      * until it finds a parent [`PageElement`](https://serenity-js.org/api/web/class/PageElement/) that matches its associated CSS selector.
      *

--- a/packages/web/src/screenplay/models/index.ts
+++ b/packages/web/src/screenplay/models/index.ts
@@ -1,6 +1,7 @@
 export * from './ArgumentDehydrator.js';
 export * from './BrowserCapabilities.js';
 export * from './BrowsingSession.js';
+export * from './ChainedElementQuestion.js';
 export * from './Cookie.js';
 export * from './CookieData.js';
 export * from './dialogs/index.js';

--- a/packages/webdriverio-8/src/screenplay/models/WebdriverIOPageElement.ts
+++ b/packages/webdriverio-8/src/screenplay/models/WebdriverIOPageElement.ts
@@ -1,7 +1,7 @@
 import 'webdriverio';
 
 import { LogicError } from '@serenity-js/core';
-import type { SwitchableOrigin } from '@serenity-js/web';
+import type { Selector, SwitchableOrigin } from '@serenity-js/web';
 import { Key, PageElement, SelectOption } from '@serenity-js/web';
 import * as scripts from '@serenity-js/web/scripts';
 
@@ -20,6 +20,15 @@ export class WebdriverIOPageElement extends PageElement<WebdriverIO.Element> {
 
     closestTo(child: WebdriverIOPageElement): WebdriverIOPageElement {
         return new WebdriverIOPageElement(this.locator.closestTo(child.locator))
+    }
+
+    element(selector: Selector): PageElement<WebdriverIO.Element> {
+        return new WebdriverIOPageElement(this.locator.createChildLocator(selector));
+    }
+
+    async elements(selector: Selector): Promise<Array<PageElement<WebdriverIO.Element>>> {
+        const childLocator = this.locator.createChildLocator(selector) as WebdriverIOLocator;
+        return childLocator.allElements();
     }
 
     async clearValue(): Promise<void> {

--- a/packages/webdriverio-8/src/screenplay/models/locators/WebdriverIOLocator.ts
+++ b/packages/webdriverio-8/src/screenplay/models/locators/WebdriverIOLocator.ts
@@ -110,6 +110,10 @@ export class WebdriverIOLocator extends Locator<WebdriverIO.Element, string> {
         return new WebdriverIOLocator(this, child.selector, this.errorHandler);
     }
 
+    createChildLocator(selector: Selector): WebdriverIOLocator {
+        return new WebdriverIOLocator(this, selector, this.errorHandler);
+    }
+
     element(): PageElement<WebdriverIO.Element> {
         return new WebdriverIOPageElement(this);
     }

--- a/packages/webdriverio/src/screenplay/models/WebdriverIOPageElement.ts
+++ b/packages/webdriverio/src/screenplay/models/WebdriverIOPageElement.ts
@@ -1,7 +1,7 @@
 import 'webdriverio';
 
 import { LogicError } from '@serenity-js/core';
-import type { SwitchableOrigin } from '@serenity-js/web';
+import type { Selector, SwitchableOrigin } from '@serenity-js/web';
 import { Key, PageElement, SelectOption } from '@serenity-js/web';
 import * as scripts from '@serenity-js/web/scripts';
 
@@ -20,6 +20,15 @@ export class WebdriverIOPageElement extends PageElement<WebdriverIO.Element> {
 
     closestTo(child: WebdriverIOPageElement): WebdriverIOPageElement {
         return new WebdriverIOPageElement(this.locator.closestTo(child.locator))
+    }
+
+    element(selector: Selector): PageElement<WebdriverIO.Element> {
+        return new WebdriverIOPageElement(this.locator.createChildLocator(selector));
+    }
+
+    async elements(selector: Selector): Promise<Array<PageElement<WebdriverIO.Element>>> {
+        const childLocator = this.locator.createChildLocator(selector) as WebdriverIOLocator;
+        return childLocator.allElements();
     }
 
     async clearValue(): Promise<void> {

--- a/packages/webdriverio/src/screenplay/models/locators/WebdriverIOLocator.ts
+++ b/packages/webdriverio/src/screenplay/models/locators/WebdriverIOLocator.ts
@@ -110,6 +110,10 @@ export class WebdriverIOLocator extends Locator<WebdriverIO.Element, string> {
         return new WebdriverIOLocator(this, child.selector, this.errorHandler);
     }
 
+    createChildLocator(selector: Selector): WebdriverIOLocator {
+        return new WebdriverIOLocator(this, selector, this.errorHandler);
+    }
+
     element(): PageElement<WebdriverIO.Element> {
         return new WebdriverIOPageElement(this);
     }


### PR DESCRIPTION
Adds fluent child element access and single-arg identity filtering to PEQL.

New capabilities:

- .element(selector) / .elements(selector) on PageElement for fluent child access
- Single-arg .where(expectation) on List for identity filtering (e.g. items.where(isVisible()).first())
- ChainedElementQuestion for .of() composability through chains
- PageElement.located() wired with metaQuestionBody for proper .of() support

