### PR TITLE
fix(html-reporter): use fuzzy matching for cross-run history

### DIFF
--- a/.kiro/steering/lessons-learned.md
+++ b/.kiro/steering/lessons-learned.md
@@ -68,6 +68,22 @@ The helper lives in `SummaryJsonWriter.ts`. If needed elsewhere, extract to a sh
 
 `z.string().datetime()` is deprecated in Zod 4. Use `z.iso.datetime()` — produces identical JSON Schema output but avoids deprecation warnings.
 
+### Cross-run history matching uses `findHistoricalMatch`, not `sceneIdentity`
+
+`sceneIdentity()` produces exact `path:line` keys for **within-run** navigation identity (URLs, scenario detail routing). `findHistoricalMatch()` uses 2-of-3 fuzzy matching (path, line, name) for **cross-run** history — resilient to both renames and moves within a file. New code that correlates the same test across different runs must use `findHistoricalMatch` (or `groupOutcomesByScene` for bulk grouping), never `sceneIdentity`.
+
+### `groupOutcomesByScene` is the shared cross-run grouping primitive
+
+Both consistency scoring (`computeConsistencyAtRun`) and unstable test detection (`identifyUnstableTests`) delegate to `groupOutcomesByScene` in `model/groupScenes.ts`. New cross-run analysis should use it rather than rolling its own grouping loop. It returns `SceneOutcomeGroup[]` with `representative`, `outcomes`, and `labels`.
+
+### `effectiveOutcome` centralises the retried-pass classification
+
+A retried pass is classified as `RETRIED_SUCCESS` (distinct from `SUCCESS`) for consistency analysis. This logic lives in `effectiveOutcome()` in `model/outcomes.ts`. Do not inline the `retries > 0 && outcome === SUCCESS` ternary — call `effectiveOutcome(scene)` instead.
+
+### Client-side code reuses server-side matching via `app/utils/navigation.ts` adapters
+
+`findHistoricalMatch`, `sceneIdentity`, and `tagDiscriminator` from `cli/model/sceneIdentity.ts` are wrapped in `app/utils/navigation.ts` with client-friendly signatures (optional `line`, optional `tags`). Browser-side code imports from the adapter, not from the server module directly.
+
 ---
 
 ## HTML Reporter — CSS & Layout

--- a/integration/html-reporter/examples/specs/accessibility.spec.ts
+++ b/integration/html-reporter/examples/specs/accessibility.spec.ts
@@ -1,0 +1,24 @@
+import { Ensure, isPresent } from '@serenity-js/assertions';
+import { Task, the } from '@serenity-js/core';
+import { describe, it } from '@serenity-js/playwright-test';
+import { Navigate, Page } from '@serenity-js/web';
+
+describe('Accessibility', () => {
+
+    const urls = [
+        '/index.html',
+        '/index.html?page=about',
+        '/index.html?page=contact',
+    ];
+
+    for (const url of urls) {
+        it(`should have no accessibility violations at ${ url }`, async ({ actor }) => {
+            await actor.attemptsTo(
+                Navigate.to(url),
+                Task.where(the`#actor assesses accessibility of ${ url }`,
+                    Ensure.that(Page.current().title(), isPresent()),
+                ),
+            );
+        });
+    }
+});

--- a/integration/html-reporter/spec/capabilities/capability-health.spec.ts
+++ b/integration/html-reporter/spec/capabilities/capability-health.spec.ts
@@ -10,7 +10,7 @@ describe('Capabilities', () => {
             await actor.attemptsTo(
                 capabilitiesView.open(),
 
-                Ensure.that(capabilitiesView.confidence(), includes('84')),
+                Ensure.that(capabilitiesView.confidence(), includes('86')),
             );
         });
 

--- a/integration/html-reporter/spec/dashboard/confidence-and-kpis.spec.ts
+++ b/integration/html-reporter/spec/dashboard/confidence-and-kpis.spec.ts
@@ -8,14 +8,14 @@ describe('Dashboard', () => {
 
         it('shows the overall confidence score', { tag: '@showcase' }, async ({ actor, dashboardView }) => {
             await actor.attemptsTo(
-                Ensure.that(dashboardView.kpiCardCalled('Confidence').value(), includes('84')),
+                Ensure.that(dashboardView.kpiCardCalled('Confidence').value(), includes('85')),
                 Ensure.that(dashboardView.kpiCardCalled('Confidence').subtitle(), includes('since last run')),
             );
         });
 
         it('shows the pass rate with the number of passing scenarios', async ({ actor, dashboardView }) => {
             await actor.attemptsTo(
-                Ensure.that(dashboardView.kpiCardCalled('Pass Rate').value(), includes('71')),
+                Ensure.that(dashboardView.kpiCardCalled('Pass Rate').value(), includes('74')),
                 Ensure.that(dashboardView.kpiCardCalled('Pass Rate').subtitle(), includes('passing')),
             );
         });
@@ -28,7 +28,7 @@ describe('Dashboard', () => {
 
         it('shows the consistency percentage', async ({ actor, dashboardView }) => {
             await actor.attemptsTo(
-                Ensure.that(dashboardView.kpiCardCalled('Consistency').value(), includes('83')),
+                Ensure.that(dashboardView.kpiCardCalled('Consistency').value(), includes('84')),
             );
         });
     });

--- a/integration/html-reporter/spec/navigation/summary-json.spec.ts
+++ b/integration/html-reporter/spec/navigation/summary-json.spec.ts
@@ -1,4 +1,5 @@
 import { Ensure, equals, includes } from '@serenity-js/assertions';
+import type { ReportSummaryJson } from '@serenity-js/html-reporter';
 import { GetRequest, LastResponse, Send } from '@serenity-js/rest';
 
 import { describe, it } from '../../src';
@@ -25,50 +26,50 @@ describe('Report', () => {
         it('identifies the report title and schema version', async ({ actor }) => {
             await actor.attemptsTo(
                 Send.a(GetRequest.to('/single/summary.json')),
-                Ensure.that(LastResponse.body<{ title: string }>().title, equals('Test Project')),
-                Ensure.that(LastResponse.body<{ schemaVersion: number }>().schemaVersion, equals(1)),
-                Ensure.that(LastResponse.body<{ runs: number }>().runs, equals(3)),
+                Ensure.that(LastResponse.body<ReportSummaryJson>().title, equals('Test Project')),
+                Ensure.that(LastResponse.body<ReportSummaryJson>().schemaVersion, equals(1)),
+                Ensure.that(LastResponse.body<ReportSummaryJson>().runs, equals(3)),
             );
         });
 
         it('reports the outcome totals for the latest run', async ({ actor }) => {
             await actor.attemptsTo(
                 Send.a(GetRequest.to('/single/summary.json')),
-                Ensure.that(LastResponse.body<{ latestRun: { totals: { passed: number } } }>().latestRun.totals.passed, equals(17)),
-                Ensure.that(LastResponse.body<{ latestRun: { totals: { failed: number } } }>().latestRun.totals.failed, equals(2)),
-                Ensure.that(LastResponse.body<{ latestRun: { totals: { error: number } } }>().latestRun.totals.error, equals(5)),
+                Ensure.that(LastResponse.body<ReportSummaryJson>().latestRun.totals.passed, equals(20)),
+                Ensure.that(LastResponse.body<ReportSummaryJson>().latestRun.totals.failed, equals(2)),
+                Ensure.that(LastResponse.body<ReportSummaryJson>().latestRun.totals.error, equals(5)),
             );
         });
 
         it('groups failures into clusters by error fingerprint', async ({ actor }) => {
             await actor.attemptsTo(
                 Send.a(GetRequest.to('/single/summary.json')),
-                Ensure.that(LastResponse.body<{ failureClusters: unknown[] }>().failureClusters.length, equals(7)),
+                Ensure.that(LastResponse.body<ReportSummaryJson>().failureClusters.length, equals(7)),
             );
         });
 
         it('reports consistency classifications', async ({ actor }) => {
             await actor.attemptsTo(
                 Send.a(GetRequest.to('/single/summary.json')),
-                Ensure.that(LastResponse.body<{ consistency: { flaky: unknown[] } }>().consistency.flaky.length, equals(1)),
-                Ensure.that(LastResponse.body<{ consistency: { degraded: unknown[] } }>().consistency.degraded.length, equals(4)),
-                Ensure.that(LastResponse.body<{ consistency: { recovered: unknown[] } }>().consistency.recovered.length, equals(2)),
+                Ensure.that(LastResponse.body<ReportSummaryJson>().consistency.flaky.length, equals(1)),
+                Ensure.that(LastResponse.body<ReportSummaryJson>().consistency.degraded.length, equals(4)),
+                Ensure.that(LastResponse.body<ReportSummaryJson>().consistency.recovered.length, equals(2)),
             );
         });
 
         it('computes composite quality scores', async ({ actor }) => {
             await actor.attemptsTo(
                 Send.a(GetRequest.to('/single/summary.json')),
-                Ensure.that(LastResponse.body<{ scores: { passRate: number } }>().scores.passRate, equals(70.8)),
-                Ensure.that(LastResponse.body<{ scores: { completeness: number } }>().scores.completeness, equals(100)),
-                Ensure.that(LastResponse.body<{ scores: { confidence: number } }>().scores.confidence, equals(82.5)),
+                Ensure.that(LastResponse.body<ReportSummaryJson>().scores.passRate, equals(74.1)),
+                Ensure.that(LastResponse.body<ReportSummaryJson>().scores.completeness, equals(100)),
+                Ensure.that(LastResponse.body<ReportSummaryJson>().scores.confidence, equals(84.4)),
             );
         });
 
         it('omits per-module breakdown for single-module runs', async ({ actor }) => {
             await actor.attemptsTo(
                 Send.a(GetRequest.to('/single/summary.json')),
-                Ensure.that(LastResponse.body<{ modules: unknown }>().modules, equals(undefined)),
+                Ensure.that(LastResponse.body<ReportSummaryJson>().modules, equals(undefined)),
             );
         });
     });

--- a/integration/html-reporter/spec/scenarios/dynamic-tests.spec.ts
+++ b/integration/html-reporter/spec/scenarios/dynamic-tests.spec.ts
@@ -1,0 +1,62 @@
+import { Ensure, equals, includes, isGreaterThan } from '@serenity-js/assertions';
+
+import { describe, it } from '../../src';
+
+const dynamicTestA = 'should have no accessibility violations at /index.html';
+const dynamicTestB = 'should have no accessibility violations at /index.html?page=about';
+const dynamicTestC = 'should have no accessibility violations at /index.html?page=contact';
+
+describe('Test Scenarios', () => {
+
+    describe('Dynamically Generated Tests', () => {
+
+        it('navigates to the correct detail view for each for-loop-generated scenario', async ({ actor, scenariosView, scenarioDetailView }) => {
+            await actor.attemptsTo(
+                scenariosView.open(),
+                scenariosView.find('accessibility violations'),
+
+                Ensure.that(scenariosView.scenarioCount(), equals(3)),
+            );
+
+            // Click into the first dynamic scenario and verify the correct detail is shown
+            await actor.attemptsTo(
+                scenariosView.scenarioCalled(dynamicTestA).viewDetails(),
+                Ensure.that(scenarioDetailView.scenarioName(), includes(dynamicTestA)),
+            );
+        });
+
+        it('navigates to a different for-loop-generated scenario than the first', async ({ actor, scenariosView, scenarioDetailView }) => {
+            await actor.attemptsTo(
+                scenariosView.open(),
+                scenariosView.find('accessibility violations'),
+
+                scenariosView.scenarioCalled(dynamicTestB).viewDetails(),
+                Ensure.that(scenarioDetailView.scenarioName(), includes(dynamicTestB)),
+            );
+        });
+
+        it('navigates to the third for-loop-generated scenario', async ({ actor, scenariosView, scenarioDetailView }) => {
+            await actor.attemptsTo(
+                scenariosView.open(),
+                scenariosView.find('accessibility violations'),
+
+                scenariosView.scenarioCalled(dynamicTestC).viewDetails(),
+                Ensure.that(scenarioDetailView.scenarioName(), includes(dynamicTestC)),
+            );
+        });
+
+        it('tracks execution history separately for each for-loop-generated scenario', async ({ actor, scenariosView, scenarioDetailView }) => {
+            // Dynamic tests sharing the same source line should each have their own
+            // execution history across runs, not share a single merged history
+            await actor.attemptsTo(
+                scenariosView.open(),
+                scenariosView.find('accessibility violations'),
+
+                // Navigate to the first dynamic test and verify it has history
+                scenariosView.scenarioCalled(dynamicTestA).viewDetails(),
+                Ensure.that(scenarioDetailView.scenarioName(), includes(dynamicTestA)),
+                Ensure.that(scenarioDetailView.executionHistoryDotCount(), isGreaterThan(1)),
+            );
+        });
+    });
+});

--- a/integration/html-reporter/spec/scenarios/finding-scenarios.spec.ts
+++ b/integration/html-reporter/spec/scenarios/finding-scenarios.spec.ts
@@ -12,7 +12,7 @@ describe('Test Scenarios', () => {
                 scenariosView.open(),
 
                 Ensure.that(scenariosView.scenarioCount(), isGreaterThan(0)),
-                Ensure.that(scenariosView.scenarioCount(), isLessThan(24)),
+                Ensure.that(scenariosView.scenarioCount(), isLessThan(30)),
             );
         });
 

--- a/packages/html-reporter/app/components/dashboard/DashboardView.ts
+++ b/packages/html-reporter/app/components/dashboard/DashboardView.ts
@@ -4,7 +4,7 @@ import { useMemo } from 'preact/hooks';
 
 import type { ReportCapabilityNode, ReportHistoryEntry, ReportInconsistentTest, ReportScenario, ReportScenarioRef, ReportSummary, ReportSystemContext } from '../../../src/cli/reporting/ReportData.js';
 import { computeDashboardScores } from '../../utils/computeDashboardScores.js';
-import { sceneIdentity, tagDiscriminator } from '../../utils/navigation.js';
+import { findHistoricalMatch, sceneIdentity } from '../../utils/navigation.js';
 import { classifyConsistencyKind } from '../../utils/selectors.js';
 import { TrendChart } from '../common/charts/TrendChart.js';
 import { ViewTopbar } from '../common/ViewTopbar.js';
@@ -43,38 +43,7 @@ function confidenceSubtitle({ confidence, previousConfidence, totalScenarios, ru
 
 function createHistoryLookup(scenarios: ReportScenario[]): (t: ReportScenarioRef) => Array<{ outcome: string }> {
     return (t: ReportScenarioRef) => {
-        const hasLine = t.source.line !== undefined;
-        const key = t.source.path + ':' + (t.source.line || '');
-        const discriminator = tagDiscriminator(t.tags);
-
-        let match: ReportScenario | undefined;
-
-        if (discriminator) {
-            // With discriminator: try key first (only if line exists), then name+path
-            if (hasLine) {
-                match = scenarios.find(s =>
-                    s.source.path + ':' + (s.source.line || '') === key &&
-                    tagDiscriminator(s.tags) === discriminator
-                );
-            }
-            match ??= scenarios.find(s =>
-                s.name === t.name &&
-                s.source.path === t.source.path &&
-                tagDiscriminator(s.tags) === discriminator
-            );
-        } else {
-            // Without discriminator: try key first (only if line exists), then name+path
-            if (hasLine) {
-                match = scenarios.find(s =>
-                    s.source.path + ':' + (s.source.line || '') === key
-                );
-            }
-            match ??= scenarios.find(s =>
-                s.name === t.name &&
-                s.source.path === t.source.path
-            );
-        }
-
+        const match = findHistoricalMatch(t, scenarios);
         return match?.executionHistory?.slice(-5) ?? [];
     };
 }

--- a/packages/html-reporter/app/hooks/useScenarioDetail.ts
+++ b/packages/html-reporter/app/hooks/useScenarioDetail.ts
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useRef, useState } from 'preact/hooks';
 
-import type { ReportActivity, ReportAttempt, ReportError, ReportExecutionHistoryEntry, ReportHistoryEntry, ReportScenario } from '../../src/cli/reporting/ReportData.js';
+import type { ReportActivity, ReportAttempt, ReportError, ReportExecutionHistoryEntry, ReportHistoryEntry, ReportScenario, ReportScenarioTag } from '../../src/cli/reporting/ReportData.js';
 import { resolveRunIndex, useHashHistory } from '../utils/index.js';
 
 export interface ScenarioDetailState {
@@ -111,25 +111,26 @@ function findMatchingScenario(
 ): ReportScenario | null {
     const decoded = decodeURIComponent(cleanId);
 
+    const matchesTag = (tags: ReportScenarioTag[], type: string, value: string | null): boolean =>
+        !value || tags.some(t => t.type === type && t.name === value);
+
     const candidates = scenarios.filter(s => {
         const tags = s.tags || [];
-        if (browserString && !tags.some(t => t.type === 'browser' && t.name === browserString)) return false;
-        if (projectString && !tags.some(t => t.type === 'project' && t.name === projectString)) return false;
-        if (platformString && !tags.some(t => t.type === 'platform' && t.name === platformString)) return false;
-        return true;
+        return matchesTag(tags, 'browser', browserString)
+            && matchesTag(tags, 'project', projectString)
+            && matchesTag(tags, 'platform', platformString);
     });
 
     // First: try exact match on collision-aware id
-    const exactMatch = candidates.find(s => s.id === decoded);
-    if (exactMatch) return exactMatch;
-
     // Fallback: match by source key (backward compatible with old bookmarked URLs)
-    return candidates.find(s => {
-        const sourceKey = s.source.line
-            ? s.source.path + ':' + s.source.line
-            : s.source.path + ':' + s.name;
-        return sourceKey === decoded;
-    }) || null;
+    return candidates.find(s => s.id === decoded)
+        ?? candidates.find(s => {
+            const sourceKey = s.source.line
+                ? s.source.path + ':' + s.source.line
+                : s.source.path + ':' + s.name;
+            return sourceKey === decoded;
+        })
+        ?? null;
 }
 
 function resolveScenarioViewData(scenario: ReportScenario, runIndex: number | null, activeAttempt: number, history: ReportHistoryEntry[]) {

--- a/packages/html-reporter/app/hooks/useScenarioDetail.ts
+++ b/packages/html-reporter/app/hooks/useScenarioDetail.ts
@@ -109,17 +109,26 @@ function parseScenarioParameters(scenarioId: string) {
 function findMatchingScenario(
     scenarios: ReportScenario[], cleanId: string, projectString: string | null, browserString: string | null, platformString: string | null,
 ): ReportScenario | null {
-    return scenarios.find(s => {
-        const sourceKey = s.source.line
-            ? s.source.path + ':' + s.source.line
-            : s.source.path + ':' + s.name;
-        const idMatch = sourceKey === decodeURIComponent(cleanId) || s.id === cleanId;
-        if (!idMatch) return false;
+    const decoded = decodeURIComponent(cleanId);
+
+    const candidates = scenarios.filter(s => {
         const tags = s.tags || [];
         if (browserString && !tags.some(t => t.type === 'browser' && t.name === browserString)) return false;
         if (projectString && !tags.some(t => t.type === 'project' && t.name === projectString)) return false;
         if (platformString && !tags.some(t => t.type === 'platform' && t.name === platformString)) return false;
         return true;
+    });
+
+    // First: try exact match on collision-aware id
+    const exactMatch = candidates.find(s => s.id === decoded);
+    if (exactMatch) return exactMatch;
+
+    // Fallback: match by source key (backward compatible with old bookmarked URLs)
+    return candidates.find(s => {
+        const sourceKey = s.source.line
+            ? s.source.path + ':' + s.source.line
+            : s.source.path + ':' + s.name;
+        return sourceKey === decoded;
     }) || null;
 }
 

--- a/packages/html-reporter/app/utils/navigation.ts
+++ b/packages/html-reporter/app/utils/navigation.ts
@@ -1,4 +1,4 @@
-import { sceneIdentity as serverSceneIdentity, tagDiscriminator as serverTagDiscriminator } from '../../src/cli/model/sceneIdentity.js';
+import { findHistoricalMatch as serverFindHistoricalMatch, sceneIdentity as serverSceneIdentity, tagDiscriminator as serverTagDiscriminator } from '../../src/cli/model/sceneIdentity.js';
 import type { ReportScenarioTag, ReportSource } from '../../src/cli/reporting/ReportData.js';
 import { link } from './link.js';
 
@@ -12,6 +12,28 @@ import { link } from './link.js';
 export function tagDiscriminator(tags?: ReportScenarioTag[]): string {
     if (!tags) return '';
     return serverTagDiscriminator(tags);
+}
+
+/**
+ * Finds the best-matching candidate for a scenario using 2-of-3 fuzzy matching.
+ * Delegates to the server-side implementation, adapting the client-side types
+ * where `line` and `tags` may be optional.
+ */
+export function findHistoricalMatch<T extends { source: { path: string; line?: number }; name: string; tags?: Array<{ type: string; name: string }> }>(
+    scene: { source: { path: string; line?: number }; name: string; tags?: Array<{ type: string; name: string }> },
+    candidates: T[],
+): T | undefined {
+    const adapt = (s: { source: { path: string; line?: number }; name: string; tags?: Array<{ type: string; name: string }> }) => ({
+        source: { path: s.source.path, line: s.source.line as number },
+        name: s.name,
+        tags: s.tags || [],
+    });
+
+    // Build adapted candidates alongside originals so we can return the original
+    const adapted = candidates.map(c => adapt(c));
+    const match = serverFindHistoricalMatch(adapt(scene), adapted);
+    if (!match) return undefined;
+    return candidates[adapted.indexOf(match)];
 }
 
 /**
@@ -112,10 +134,11 @@ function stripAbsolutePrefix(filePath: string, specDirectory?: string): string {
     return filePath;
 }
 
-export function scenarioUrl(scenario: { source: ReportSource; name: string; tags?: ReportScenarioTag[] }, run?: number | string | null, history?: Array<{ timestamp: string }>): string {
-    const id = scenario.source.line
-        ? scenario.source.path + ':' + scenario.source.line
-        : scenario.source.path + ':' + scenario.name;
+export function scenarioUrl(scenario: { id?: string; source: ReportSource; name: string; tags?: ReportScenarioTag[] }, run?: number | string | null, history?: Array<{ timestamp: string }>): string {
+    const id = scenario.id
+        || (scenario.source.line
+            ? scenario.source.path + ':' + scenario.source.line
+            : scenario.source.path + ':' + scenario.name);
     
     // Determine run ID
     let runId: string | undefined;

--- a/packages/html-reporter/spec/cli/aggregation/mapScenarioToReport.spec.ts
+++ b/packages/html-reporter/spec/cli/aggregation/mapScenarioToReport.spec.ts
@@ -1,0 +1,145 @@
+import { expect, test } from '@playwright/test';
+import { ExecutionFailedWithAssertionError, ExecutionFailedWithError, ExecutionSuccessful } from '@serenity-js/core/model';
+
+import { buildExecutionHistory } from '../../../src/cli/aggregation/mapScenarioToReport.js';
+import type { RunData, SceneRecord } from '../../../src/cli/model/RunData.js';
+
+function createScene(overrides: Partial<SceneRecord> & { name: string; source: { path: string; line: number } }): SceneRecord {
+    return {
+        category: 'Suite',
+        outcome: { code: ExecutionSuccessful.Code },
+        duration: 1000,
+        startedAt: '2024-06-15T10:00:00.000Z',
+        tags: [],
+        activities: [],
+        ...overrides,
+    } as SceneRecord;
+}
+
+function createRun(overrides: Partial<RunData> & { scenes: SceneRecord[] }): RunData {
+    return {
+        schemaVersion: 1,
+        testRunId: 'run-1',
+        startedAt: '2024-01-01T00:00:00.000Z',
+        finishedAt: '2024-01-01T00:01:00.000Z',
+        outcomes: { passed: 1, failed: 0, pending: 0, skipped: 0, compromised: 0, error: 0 },
+        tags: [],
+        ...overrides,
+    } as RunData;
+}
+
+test.describe('buildExecutionHistory', () => {
+
+    test('matches a scene across runs by source identity', () => {
+        const scene = createScene({ name: 'test A', source: { path: 'spec/a.spec.ts', line: 10 } });
+        const run1 = createRun({
+            testRunId: 'run-1',
+            scenes: [createScene({ name: 'test A', source: { path: 'spec/a.spec.ts', line: 10 } })],
+        });
+        const run2 = createRun({
+            testRunId: 'run-2',
+            scenes: [createScene({ name: 'test A', source: { path: 'spec/a.spec.ts', line: 10 } })],
+        });
+
+        const history = buildExecutionHistory(scene, [run1, run2]);
+
+        expect(history).toHaveLength(2);
+        expect(history[0].outcome).toBe('SUCCESS');
+        expect(history[1].outcome).toBe('SUCCESS');
+    });
+
+    test('returns empty history when scene is not found in any run', () => {
+        const scene = createScene({ name: 'test missing', source: { path: 'spec/b.spec.ts', line: 99 } });
+        const run1 = createRun({
+            testRunId: 'run-1',
+            scenes: [createScene({ name: 'test A', source: { path: 'spec/a.spec.ts', line: 10 } })],
+        });
+
+        const history = buildExecutionHistory(scene, [run1]);
+
+        expect(history).toHaveLength(0);
+    });
+
+    test('disambiguates dynamically-generated tests sharing the same source line', () => {
+        const sceneA = createScene({ name: 'should pass for url A', source: { path: 'spec/a.spec.ts', line: 35 } });
+        const sceneB = createScene({ name: 'should pass for url B', source: { path: 'spec/a.spec.ts', line: 35 } });
+
+        const historicalRun = createRun({
+            testRunId: 'run-1',
+            scenes: [
+                createScene({ name: 'should pass for url A', source: { path: 'spec/a.spec.ts', line: 35 }, outcome: { code: ExecutionSuccessful.Code } }),
+                createScene({ name: 'should pass for url B', source: { path: 'spec/a.spec.ts', line: 35 }, outcome: { code: ExecutionFailedWithAssertionError.Code } }),
+            ],
+        });
+
+        const historyA = buildExecutionHistory(sceneA, [historicalRun]);
+        const historyB = buildExecutionHistory(sceneB, [historicalRun]);
+
+        // Each scene should match its own counterpart, not both match the same one
+        expect(historyA).toHaveLength(1);
+        expect(historyB).toHaveLength(1);
+        expect(historyA[0].outcome).toBe('SUCCESS');
+        expect(historyB[0].outcome).toBe('FAILURE');
+    });
+
+    test('matches the single candidate when historical run has only one test at the colliding line', () => {
+        // Latest run has 2 dynamic tests at line 35, but historical run had only 1.
+        // Both current scenes match the one historical scene — no ambiguity to resolve.
+        const sceneA = createScene({ name: 'should pass for url A', source: { path: 'spec/a.spec.ts', line: 35 } });
+        const sceneB = createScene({ name: 'should pass for url B', source: { path: 'spec/a.spec.ts', line: 35 } });
+
+        const historicalRun = createRun({
+            testRunId: 'run-1',
+            scenes: [
+                createScene({ name: 'should pass for url A', source: { path: 'spec/a.spec.ts', line: 35 }, outcome: { code: ExecutionSuccessful.Code } }),
+            ],
+        });
+
+        const historyA = buildExecutionHistory(sceneA, [historicalRun]);
+        const historyB = buildExecutionHistory(sceneB, [historicalRun]);
+
+        expect(historyA).toHaveLength(1);
+        expect(historyA[0].outcome).toBe('SUCCESS');
+        // sceneB also matches the single historical scene (no collision, backward-compatible)
+        expect(historyB).toHaveLength(1);
+        expect(historyB[0].outcome).toBe('SUCCESS');
+    });
+
+    test('still matches unique scenes at the same line when only one exists per run', () => {
+        const scene = createScene({ name: 'unique test', source: { path: 'spec/a.spec.ts', line: 10 } });
+
+        const run = createRun({
+            testRunId: 'run-1',
+            scenes: [
+                createScene({ name: 'unique test', source: { path: 'spec/a.spec.ts', line: 10 } }),
+            ],
+        });
+
+        const history = buildExecutionHistory(scene, [run]);
+
+        expect(history).toHaveLength(1);
+        expect(history[0].outcome).toBe('SUCCESS');
+    });
+
+    test('includes error info for failed matches', () => {
+        const scene = createScene({ name: 'test A', source: { path: 'spec/a.spec.ts', line: 10 } });
+
+        const run = createRun({
+            testRunId: 'run-1',
+            scenes: [
+                createScene({
+                    name: 'test A',
+                    source: { path: 'spec/a.spec.ts', line: 10 },
+                    outcome: { code: ExecutionFailedWithError.Code },
+                    error: { name: 'Error', message: 'something broke', stack: 'stack trace' },
+                }),
+            ],
+        });
+
+        const history = buildExecutionHistory(scene, [run]);
+
+        expect(history).toHaveLength(1);
+        expect(history[0].outcome).toBe('ERROR');
+        expect(history[0].error).toEqual({ name: 'Error', message: 'something broke', stack: 'stack trace' });
+    });
+});

--- a/packages/html-reporter/spec/cli/aggregation/scenarioIdAssignment.spec.ts
+++ b/packages/html-reporter/spec/cli/aggregation/scenarioIdAssignment.spec.ts
@@ -1,0 +1,85 @@
+import type * as fs from 'node:fs';
+
+import { expect, test } from '@playwright/test';
+import { FileSystem, Path, RequirementsHierarchy } from '@serenity-js/core/io';
+import { ExecutionSuccessful } from '@serenity-js/core/model';
+import { createFsFromVolume, Volume } from 'memfs';
+
+import { SingleSourceAggregator } from '../../../src/cli/aggregation/SingleSourceAggregator.js';
+import type { ReportData } from '../../../src/cli/reporting/ReportData.js';
+
+function createMemFs(tree: Record<string, unknown>, root = '/'): typeof fs {
+    return createFsFromVolume(Volume.fromNestedJSON(tree as any, root)) as unknown as typeof fs;
+}
+
+const outputDirectory = Path.from('/reports/serenity-js');
+
+const defaultSystemContext = {
+    nodeVersion: 'v22.0.0',
+    os: { name: 'linux', version: '6.0.0', arch: 'x64' },
+    serenityVersion: '3.44.0',
+    runtime: { provider: 'node', version: 'v22.0.0' },
+};
+
+function runData(data: Record<string, unknown>): string {
+    return JSON.stringify({
+        schemaVersion: 1,
+        systemContext: defaultSystemContext,
+        ...data,
+    });
+}
+
+function readDataJs(filesystem: typeof fs): ReportData {
+    const content = filesystem.readFileSync('/reports/serenity-js/data.js', 'utf8') as string;
+    const json = content.replace(/^window\.__SERENITY_REPORT_DATA__\s*=\s*/, '').replace(/;\s*$/, '');
+    return JSON.parse(json) as ReportData;
+}
+
+test.describe('ReportAggregator — scenario id assignment', () => {
+
+    test('sets a unique id on each scenario based on collision-aware identity', () => {
+        const filesystem = createMemFs({
+            [outputDirectory.value]: {
+                'test-runs': {
+                    '2024-06-15T14:30:00.000Z': {
+                        'db.json': runData({
+                            startedAt: '2024-06-15T14:30:00.000Z',
+                            finishedAt: '2024-06-15T14:30:01.000Z',
+                            outcomes: { passed: 3, failed: 0, pending: 0, skipped: 0, compromised: 0, error: 0 },
+                            scenes: [
+                                { name: 'unique test', category: 'Suite', outcome: { code: ExecutionSuccessful.Code }, duration: 100, startedAt: '2024-06-15T14:30:00.000Z', source: { path: 'spec/a.spec.ts', line: 10 }, tags: [], activities: [] },
+                                { name: 'should have no violations at /home', category: 'Suite', outcome: { code: ExecutionSuccessful.Code }, duration: 100, startedAt: '2024-06-15T14:30:00.100Z', source: { path: 'spec/a11y.spec.ts', line: 35 }, tags: [], activities: [] },
+                                { name: 'should have no violations at /about', category: 'Suite', outcome: { code: ExecutionSuccessful.Code }, duration: 100, startedAt: '2024-06-15T14:30:00.200Z', source: { path: 'spec/a11y.spec.ts', line: 35 }, tags: [], activities: [] },
+                            ],
+                            tags: [],
+                            testRunner: { name: 'Playwright', version: '1.50.0' },
+                        }),
+                    },
+                },
+            },
+        });
+
+        const fileSystem = new FileSystem(outputDirectory, filesystem);
+        const projectFileSystem = new FileSystem(Path.from('/'), filesystem);
+        const hierarchy = new RequirementsHierarchy(projectFileSystem);
+
+        const aggregator = new SingleSourceAggregator(fileSystem, { consistencyWindow: 5, buildCapabilities: false }, hierarchy, () => undefined);
+        aggregator.aggregate();
+
+        const data = readDataJs(filesystem);
+
+        // Non-colliding scene uses path:line identity
+        const uniqueScenario = data.scenarios.find(s => s.name === 'unique test');
+        expect(uniqueScenario.id).toBe('spec/a.spec.ts:10');
+
+        // Colliding scenes use path:line:name identity to disambiguate
+        const homeScenario = data.scenarios.find(s => s.name === 'should have no violations at /home');
+        const aboutScenario = data.scenarios.find(s => s.name === 'should have no violations at /about');
+        expect(homeScenario.id).toBe('spec/a11y.spec.ts:35:should have no violations at /home');
+        expect(aboutScenario.id).toBe('spec/a11y.spec.ts:35:should have no violations at /about');
+
+        // All ids are distinct
+        const ids = data.scenarios.map(s => s.id);
+        expect(new Set(ids).size).toBe(ids.length);
+    });
+});

--- a/packages/html-reporter/spec/cli/buildCapabilities-history.spec.ts
+++ b/packages/html-reporter/spec/cli/buildCapabilities-history.spec.ts
@@ -1,0 +1,83 @@
+import type * as fs from 'node:fs';
+
+import { expect, test } from '@playwright/test';
+import { FileSystem, Path, RequirementsHierarchy } from '@serenity-js/core/io';
+import { ExecutionFailedWithAssertionError, ExecutionSuccessful } from '@serenity-js/core/model';
+import { createFsFromVolume, Volume } from 'memfs';
+
+import { buildCapabilities } from '../../src/cli/capabilities/buildCapabilities.js';
+import type { RunData } from '../../src/cli/model/RunData.js';
+
+function createMemFs(tree: Record<string, unknown>, root = '/'): typeof fs {
+    return createFsFromVolume(Volume.fromNestedJSON(tree as any, root)) as unknown as typeof fs;
+}
+
+function makeRun(scenes: Array<{ name: string; path: string; line: number; outcomeCode?: number }>, testRunId = 'run-1'): RunData {
+    return {
+        startedAt: '2024-01-01T00:00:00.000Z',
+        finishedAt: '2024-01-01T00:00:01.000Z',
+        testRunId,
+        outcomes: { passed: scenes.length, failed: 0, pending: 0, skipped: 0, compromised: 0, error: 0 },
+        scenes: scenes.map((s, i) => ({
+            name: s.name,
+            category: 'Suite',
+            source: { path: s.path, line: s.line },
+            outcome: { code: s.outcomeCode ?? ExecutionSuccessful.Code },
+            tags: [],
+            activities: [],
+            startedAt: new Date(Date.parse('2024-01-01T00:00:00.000Z') + i * 100).toISOString(),
+            duration: 100,
+        })),
+        tags: [],
+        testRunner: { name: 'Playwright', version: '1.50.0' },
+    } as unknown as RunData;
+}
+
+test.describe('buildCapabilities — execution history disambiguation', () => {
+
+    test('disambiguates dynamically-generated tests sharing the same source line', () => {
+        const tree = {
+            '/project': {
+                spec: {
+                    'a11y.spec.ts': '',
+                },
+            },
+        };
+
+        const filesystem = createMemFs(tree);
+        const projectFileSystem = new FileSystem(Path.from('/project'), filesystem);
+        const hierarchy = new RequirementsHierarchy(projectFileSystem, Path.from('spec'));
+
+        // Historical run: two dynamic tests at same line, one passed, one failed
+        const historicalRun = makeRun([
+            { name: 'should have no violations at /home', path: '/project/spec/a11y.spec.ts', line: 35, outcomeCode: ExecutionSuccessful.Code },
+            { name: 'should have no violations at /about', path: '/project/spec/a11y.spec.ts', line: 35, outcomeCode: ExecutionFailedWithAssertionError.Code },
+        ], 'run-1');
+
+        // Latest run: same two dynamic tests
+        const latestRun = makeRun([
+            { name: 'should have no violations at /home', path: '/project/spec/a11y.spec.ts', line: 35, outcomeCode: ExecutionSuccessful.Code },
+            { name: 'should have no violations at /about', path: '/project/spec/a11y.spec.ts', line: 35, outcomeCode: ExecutionSuccessful.Code },
+        ], 'run-2');
+
+        const result = buildCapabilities(latestRun, [historicalRun, latestRun], hierarchy);
+
+        // The hierarchy strips the file extension — node name is 'a11y'
+        const fileNode = result.children?.find(c => c.name === 'a11y');
+        expect(fileNode).toBeDefined();
+        expect(fileNode.scenarios).toHaveLength(2);
+
+        // Each scenario should have its own distinct history
+        const homeScenario = fileNode.scenarios.find(s => s.name === 'should have no violations at /home');
+        const aboutScenario = fileNode.scenarios.find(s => s.name === 'should have no violations at /about');
+
+        expect(homeScenario).toBeDefined();
+        expect(aboutScenario).toBeDefined();
+
+        // History: [historicalRun, latestRun]
+        // Home passed in both runs
+        expect(homeScenario.executionHistory).toEqual(['SUCCESS', 'SUCCESS']);
+        // About failed in historical run, passed in latest
+        expect(aboutScenario.executionHistory).toEqual(['FAILURE', 'SUCCESS']);
+    });
+});

--- a/packages/html-reporter/spec/cli/sceneIdentity.spec.ts
+++ b/packages/html-reporter/spec/cli/sceneIdentity.spec.ts
@@ -1,6 +1,6 @@
 import { expect, test } from '@playwright/test';
 
-import { sceneIdentity, tagDiscriminator } from '../../src/cli/model/sceneIdentity.js';
+import { findHistoricalMatch, sceneIdentity, sceneIdentityWithinRun, tagDiscriminator } from '../../src/cli/model/sceneIdentity.js';
 
 test.describe('tagDiscriminator', () => {
 
@@ -122,5 +122,231 @@ test.describe('sceneIdentity', () => {
         });
 
         expect(desktop).not.toBe(mobile);
+    });
+});
+
+test.describe('sceneIdentityWithinRun', () => {
+
+    test('returns path:line when each scene has a unique source line', () => {
+        const scenes = [
+            { source: { path: 'spec/a.spec.ts', line: 10 }, name: 'test A', tags: [] },
+            { source: { path: 'spec/a.spec.ts', line: 20 }, name: 'test B', tags: [] },
+        ];
+        const identity = sceneIdentityWithinRun(scenes);
+        expect(identity(scenes[0])).toBe('spec/a.spec.ts:10');
+        expect(identity(scenes[1])).toBe('spec/a.spec.ts:20');
+    });
+
+    test('appends name when multiple scenes share the same source line', () => {
+        const scenes = [
+            { source: { path: 'spec/a.spec.ts', line: 35 }, name: 'should have no violations at https://example.com', tags: [] },
+            { source: { path: 'spec/a.spec.ts', line: 35 }, name: 'should have no violations at https://example.com/about', tags: [] },
+        ];
+        const identity = sceneIdentityWithinRun(scenes);
+        expect(identity(scenes[0])).toBe('spec/a.spec.ts:35:should have no violations at https://example.com');
+        expect(identity(scenes[1])).toBe('spec/a.spec.ts:35:should have no violations at https://example.com/about');
+    });
+
+    test('only disambiguates colliding scenes — non-colliding scenes keep path:line', () => {
+        const scenes = [
+            { source: { path: 'spec/a.spec.ts', line: 10 }, name: 'unique test', tags: [] },
+            { source: { path: 'spec/a.spec.ts', line: 35 }, name: 'dynamic test 1', tags: [] },
+            { source: { path: 'spec/a.spec.ts', line: 35 }, name: 'dynamic test 2', tags: [] },
+        ];
+        const identity = sceneIdentityWithinRun(scenes);
+        expect(identity(scenes[0])).toBe('spec/a.spec.ts:10');
+        expect(identity(scenes[1])).toBe('spec/a.spec.ts:35:dynamic test 1');
+        expect(identity(scenes[2])).toBe('spec/a.spec.ts:35:dynamic test 2');
+    });
+
+    test('includes tag discriminator alongside name disambiguation', () => {
+        const scenes = [
+            { source: { path: 'spec/a.spec.ts', line: 35 }, name: 'test at url A', tags: [{ type: 'browser', name: 'chromium 149' }] },
+            { source: { path: 'spec/a.spec.ts', line: 35 }, name: 'test at url B', tags: [{ type: 'browser', name: 'chromium 149' }] },
+        ];
+        const identity = sceneIdentityWithinRun(scenes);
+        expect(identity(scenes[0])).toBe('spec/a.spec.ts:35:test at url A@chromium 149');
+        expect(identity(scenes[1])).toBe('spec/a.spec.ts:35:test at url B@chromium 149');
+    });
+
+    test('detects collision per base identity including tag discriminator', () => {
+        // Same path:line but different projects — these are already disambiguated by tags, no name needed
+        const scenes = [
+            { source: { path: 'spec/a.spec.ts', line: 35 }, name: 'checkout', tags: [{ type: 'project', name: 'desktop' }] },
+            { source: { path: 'spec/a.spec.ts', line: 35 }, name: 'checkout', tags: [{ type: 'project', name: 'mobile' }] },
+        ];
+        const identity = sceneIdentityWithinRun(scenes);
+        expect(identity(scenes[0])).toBe('spec/a.spec.ts:35@desktop');
+        expect(identity(scenes[1])).toBe('spec/a.spec.ts:35@mobile');
+    });
+
+    test('detects collision when same path:line AND same tags produce duplicate base identities', () => {
+        // Same path:line AND same tags — need name to disambiguate
+        const scenes = [
+            { source: { path: 'spec/a.spec.ts', line: 35 }, name: 'test url A', tags: [{ type: 'project', name: 'desktop' }] },
+            { source: { path: 'spec/a.spec.ts', line: 35 }, name: 'test url B', tags: [{ type: 'project', name: 'desktop' }] },
+        ];
+        const identity = sceneIdentityWithinRun(scenes);
+        expect(identity(scenes[0])).toBe('spec/a.spec.ts:35:test url A@desktop');
+        expect(identity(scenes[1])).toBe('spec/a.spec.ts:35:test url B@desktop');
+    });
+
+    test('falls back to path:name when line is 0', () => {
+        const scenes = [
+            { source: { path: 'spec/a.spec.ts', line: 0 }, name: 'manual test A', tags: [] },
+            { source: { path: 'spec/a.spec.ts', line: 0 }, name: 'manual test B', tags: [] },
+        ];
+        const identity = sceneIdentityWithinRun(scenes);
+        // line 0 is falsy, so base is path:name — already unique by name
+        expect(identity(scenes[0])).toBe('spec/a.spec.ts:manual test A');
+        expect(identity(scenes[1])).toBe('spec/a.spec.ts:manual test B');
+    });
+
+    test('returns the same identity when called multiple times for the same scene', () => {
+        const scenes = [
+            { source: { path: 'spec/a.spec.ts', line: 35 }, name: 'test 1', tags: [] },
+            { source: { path: 'spec/a.spec.ts', line: 35 }, name: 'test 2', tags: [] },
+        ];
+        const identity = sceneIdentityWithinRun(scenes);
+        const first = identity(scenes[0]);
+        const second = identity(scenes[0]);
+        expect(first).toBe(second);
+    });
+});
+
+test.describe('findHistoricalMatch', () => {
+
+    const scene = (overrides: Partial<{ name: string; path: string; line: number; tags: Array<{ type: string; name: string }> }> = {}) => ({
+        name: overrides.name ?? 'should complete checkout',
+        source: { path: overrides.path ?? 'spec/checkout.spec.ts', line: overrides.line ?? 10 },
+        tags: overrides.tags ?? [],
+    });
+
+    test('returns undefined when no candidates are provided', () => {
+        const result = findHistoricalMatch(scene(), []);
+        expect(result).toBeUndefined();
+    });
+
+    test('matches exactly when all three fields agree (3/3)', () => {
+        const current = scene();
+        const candidate = scene();
+        expect(findHistoricalMatch(current, [candidate])).toBe(candidate);
+    });
+
+    test('matches a renamed test (same path + same line, different name — 2/3)', () => {
+        const current = scene({ name: 'should complete checkout v2' });
+        const candidate = scene({ name: 'should complete checkout' });
+        expect(findHistoricalMatch(current, [candidate])).toBe(candidate);
+    });
+
+    test('matches a moved test (same path + same name, different line — 2/3)', () => {
+        const current = scene({ line: 25 });
+        const candidate = scene({ line: 10 });
+        expect(findHistoricalMatch(current, [candidate])).toBe(candidate);
+    });
+
+    test('does not match when only path agrees (1/3)', () => {
+        const current = scene({ name: 'completely different test', line: 99 });
+        const candidate = scene();
+        expect(findHistoricalMatch(current, [candidate])).toBeUndefined();
+    });
+
+    test('does not match when only name agrees (1/3)', () => {
+        const current = scene({ path: 'spec/other.spec.ts', line: 99 });
+        const candidate = scene();
+        expect(findHistoricalMatch(current, [candidate])).toBeUndefined();
+    });
+
+    test('does not match when only line agrees (1/3)', () => {
+        const current = scene({ path: 'spec/other.spec.ts', name: 'unrelated test' });
+        const candidate = scene();
+        expect(findHistoricalMatch(current, [candidate])).toBeUndefined();
+    });
+
+    test('does not match when no fields agree (0/3)', () => {
+        const current = scene({ path: 'spec/other.spec.ts', name: 'unrelated', line: 99 });
+        const candidate = scene();
+        expect(findHistoricalMatch(current, [candidate])).toBeUndefined();
+    });
+
+    test.describe('tiebreaking', () => {
+
+        test('prefers a 3/3 match over a 2/3 match', () => {
+            const current = scene({ name: 'checkout', line: 10 });
+            const exact = scene({ name: 'checkout', line: 10 });
+            const partial = scene({ name: 'checkout', line: 20 }); // path+name only
+
+            expect(findHistoricalMatch(current, [partial, exact])).toBe(exact);
+        });
+
+        test('prefers path+name over path+line when both score 2/3', () => {
+            const current = scene({ name: 'checkout', line: 15 });
+            const pathAndName = scene({ name: 'checkout', line: 20 }); // path+name
+            const pathAndLine = scene({ name: 'other test', line: 15 }); // path+line
+
+            expect(findHistoricalMatch(current, [pathAndLine, pathAndName])).toBe(pathAndName);
+        });
+
+        test('prefers path+line over line+name when both score 2/3', () => {
+            const current = scene({ path: 'spec/checkout.spec.ts', name: 'checkout', line: 10 });
+            const pathAndLine = scene({ path: 'spec/checkout.spec.ts', name: 'renamed', line: 10 }); // path+line
+            const lineAndName = scene({ path: 'spec/other.spec.ts', name: 'checkout', line: 10 }); // line+name
+
+            expect(findHistoricalMatch(current, [lineAndName, pathAndLine])).toBe(pathAndLine);
+        });
+
+        test('prefers path+name over line+name when both score 2/3', () => {
+            const current = scene({ path: 'spec/checkout.spec.ts', name: 'checkout', line: 15 });
+            const pathAndName = scene({ path: 'spec/checkout.spec.ts', name: 'checkout', line: 20 }); // path+name
+            const lineAndName = scene({ path: 'spec/other.spec.ts', name: 'checkout', line: 15 }); // line+name
+
+            expect(findHistoricalMatch(current, [lineAndName, pathAndName])).toBe(pathAndName);
+        });
+    });
+
+    test.describe('tag discriminator gate', () => {
+
+        test('does not match when tag discriminators differ', () => {
+            const current = scene({ tags: [{ type: 'project', name: 'desktop' }] });
+            const candidate = scene({ tags: [{ type: 'project', name: 'mobile' }] });
+
+            expect(findHistoricalMatch(current, [candidate])).toBeUndefined();
+        });
+
+        test('matches when tag discriminators are identical', () => {
+            const current = scene({ tags: [{ type: 'project', name: 'desktop' }] });
+            const candidate = scene({ tags: [{ type: 'project', name: 'desktop' }] });
+
+            expect(findHistoricalMatch(current, [candidate])).toBe(candidate);
+        });
+
+        test('skips candidates with wrong discriminator even if all three fields match', () => {
+            const current = scene({ tags: [{ type: 'module', name: 'playwright-web' }] });
+            const wrongModule = scene({ tags: [{ type: 'module', name: 'webdriverio-web' }] });
+            const rightModule = scene({ name: 'should complete checkout v2', tags: [{ type: 'module', name: 'playwright-web' }] }); // only 2/3
+
+            expect(findHistoricalMatch(current, [wrongModule, rightModule])).toBe(rightModule);
+        });
+    });
+
+    test.describe('multiple candidates', () => {
+
+        test('selects the best match among several candidates', () => {
+            const current = scene({ name: 'checkout', line: 10 });
+            const noMatch = scene({ name: 'unrelated', line: 99 }); // path only = 1/3
+            const partial = scene({ name: 'checkout', line: 20 }); // path+name = 2/3
+            const exact = scene({ name: 'checkout', line: 10 }); // 3/3
+
+            expect(findHistoricalMatch(current, [noMatch, partial, exact])).toBe(exact);
+        });
+
+        test('returns first best match when multiple candidates tie at the same score and tiebreaker', () => {
+            const current = scene({ name: 'checkout', line: 15 });
+            const first = scene({ name: 'checkout', line: 20 }); // path+name
+            const second = scene({ name: 'checkout', line: 30 }); // path+name (same tiebreaker)
+
+            // Both score equally — first encountered wins
+            expect(findHistoricalMatch(current, [first, second])).toBe(first);
+        });
     });
 });

--- a/packages/html-reporter/src/cli/aggregation/ReportAggregator.ts
+++ b/packages/html-reporter/src/cli/aggregation/ReportAggregator.ts
@@ -6,6 +6,7 @@ import { buildHistory } from '../history/buildHistory.js';
 import {
     IncompatibleSchemaError,
     InvalidRunDataError,
+    sceneIdentityWithinRun,
     validateRunData
 } from '../model/index.js';
 import type { RunData } from '../model/RunData.js';
@@ -160,9 +161,12 @@ export abstract class ReportAggregator {
     }
 
     private enrichScenarios(latestRun: RunData, allRuns: RunData[]): ReportScenario[] {
+        const identity = sceneIdentityWithinRun(latestRun.scenes);
         return latestRun.scenes.map(scene => {
             const executionHistory = buildExecutionHistory(scene, allRuns);
-            return enrichSingleScenario(scene, executionHistory);
+            const enriched = enrichSingleScenario(scene, executionHistory);
+            enriched.id = identity(scene);
+            return enriched;
         });
     }
 

--- a/packages/html-reporter/src/cli/aggregation/identifyUnstableTests.ts
+++ b/packages/html-reporter/src/cli/aggregation/identifyUnstableTests.ts
@@ -1,7 +1,7 @@
 import { ExecutionSuccessful } from '@serenity-js/core/model';
 
-import { resolveRunLabel, sceneIdentity } from '../model/index.js';
-import { outcomeCodeToDisplayString } from '../model/outcomes.js';
+import { groupOutcomesByScene } from '../model/groupScenes.js';
+import { findHistoricalMatch } from '../model/index.js';
 import type { RunData, TagRecord } from '../model/RunData.js';
 
 /**
@@ -16,44 +16,22 @@ export function identifyUnstableTests(
     consistencyWindow: number,
 ): Array<{ name: string; category: string; source: { path: string; line: number }; tags: TagRecord[]; inconsistencyRate: number; history: string[]; labels: string[] }> {
     const recentRuns = allRuns.slice(-consistencyWindow);
+    const groups = groupOutcomesByScene(recentRuns);
 
-    // Collect outcomes per test identity (name@path@project)
-    // Including the project tag ensures different browser/OS variations are tracked separately
-    const testOutcomes = new Map<string, { name: string; category: string; source: { path: string; line: number }; tags: TagRecord[]; outcomes: string[]; labels: string[] }>();
-
-    for (const run of recentRuns) {
-        const runLabel = resolveRunLabel(run);
-        for (const scene of run.scenes) {
-            const identity = sceneIdentity(scene);
-            if (!testOutcomes.has(identity)) {
-                testOutcomes.set(identity, { name: scene.name, category: scene.category, source: scene.source, tags: scene.tags, outcomes: [], labels: [] });
-            }
-            const entry = testOutcomes.get(identity);
-
-            // A retried pass counts as a distinct outcome signal
-            const effectiveOutcome = (scene.retries > 0 && scene.outcome.code === ExecutionSuccessful.Code)
-                ? 'RETRIED_SUCCESS'
-                : outcomeCodeToDisplayString(scene.outcome.code);
-            entry.outcomes.push(effectiveOutcome);
-            entry.labels.push(runLabel);
-        }
-    }
-
-    // Find tests with mixed outcomes or any retried success
     const unstable: Array<{ name: string; category: string; source: { path: string; line: number }; tags: TagRecord[]; inconsistencyRate: number; history: string[]; labels: string[] }> = [];
 
-    for (const [, test] of testOutcomes) {
-        const uniqueOutcomes = new Set(test.outcomes);
-        if (uniqueOutcomes.size > 1 || test.outcomes.includes('RETRIED_SUCCESS')) {
-            const failures = test.outcomes.filter(o => o !== 'SUCCESS').length;
+    for (const group of groups) {
+        const uniqueOutcomes = new Set(group.outcomes);
+        if (uniqueOutcomes.size > 1 || group.outcomes.includes('RETRIED_SUCCESS')) {
+            const failures = group.outcomes.filter(o => o !== 'SUCCESS').length;
             unstable.push({
-                name: test.name,
-                category: test.category,
-                source: test.source,
-                tags: test.tags,
-                inconsistencyRate: failures / test.outcomes.length,
-                history: test.outcomes,
-                labels: test.labels,
+                name: group.representative.name,
+                category: group.representative.category,
+                source: group.representative.source,
+                tags: group.representative.tags,
+                inconsistencyRate: failures / group.outcomes.length,
+                history: group.outcomes,
+                labels: group.labels,
             });
         }
     }
@@ -82,13 +60,11 @@ export function computeDegradedRecovered(allRuns: RunData[]): {
 
     const latestRun = allRuns[allRuns.length - 1];
     const previousRun = allRuns[allRuns.length - 2];
-    const previousOutcomes = new Map(previousRun.scenes.map(s => [sceneIdentity(s), s.outcome.code]));
 
     for (const scene of latestRun.scenes) {
-        const key = sceneIdentity(scene);
-        const previousCode = previousOutcomes.get(key);
-        if (previousCode !== undefined) {
-            const previousSuccess = previousCode === ExecutionSuccessful.Code;
+        const match = findHistoricalMatch(scene, previousRun.scenes);
+        if (match) {
+            const previousSuccess = match.outcome.code === ExecutionSuccessful.Code;
             const currentSuccess = scene.outcome.code === ExecutionSuccessful.Code;
             const currentRetried = scene.retries > 0 && currentSuccess;
             if (previousSuccess && !currentSuccess) {

--- a/packages/html-reporter/src/cli/aggregation/mapScenarioToReport.ts
+++ b/packages/html-reporter/src/cli/aggregation/mapScenarioToReport.ts
@@ -1,7 +1,7 @@
 import { ExecutionSuccessful } from '@serenity-js/core/model';
 import { marked } from 'marked';
 
-import { resolveRunLabel, sceneIdentity } from '../model/index.js';
+import { findHistoricalMatch, resolveRunLabel } from '../model/index.js';
 import { outcomeCodeToDisplayString } from '../model/outcomes.js';
 import type { ActivityRecord, RunData, SceneRecord } from '../model/RunData.js';
 import type {
@@ -70,12 +70,15 @@ export function enrichSingleScenario(scene: SceneRecord, executionHistory: Repor
 /**
  * Builds the execution history for a scene across all available runs.
  *
+ * When multiple scenes in a historical run share the same base identity
+ * (e.g., dynamically-generated tests at the same source line), the scene
+ * name is used as a secondary disambiguator to match the correct entry.
+ *
  * @internal
  */
 export function buildExecutionHistory(scene: SceneRecord, allRuns: RunData[]): ReportExecutionHistoryEntry[] {
-    const key = sceneIdentity(scene);
     return allRuns.map(run => {
-        const match = run.scenes.find(s => sceneIdentity(s) === key);
+        const match = findHistoricalMatch(scene, run.scenes);
         if (!match) return undefined;
         const entry: ReportExecutionHistoryEntry = {
             outcome: outcomeCodeToDisplayString(match.outcome.code),

--- a/packages/html-reporter/src/cli/capabilities/buildCapabilities.ts
+++ b/packages/html-reporter/src/cli/capabilities/buildCapabilities.ts
@@ -4,7 +4,7 @@ import { Path } from '@serenity-js/core/io';
 import { scoreCapability, scoreDirectory } from '../analysis/CapabilityConfidenceScorer.js';
 import { mapOutcomeToKey, outcomeCodeToDisplayString } from '../model/outcomes.js';
 import type { RunData, SceneRecord } from '../model/RunData.js';
-import { sceneIdentity } from '../model/sceneIdentity.js';
+import { findHistoricalMatch } from '../model/sceneIdentity.js';
 import type { ReportCapabilityNode, ReportOutcomes } from '../reporting/ReportData.js';
 import { renderReadmeHtml } from './renderReadme.js';
 
@@ -73,14 +73,15 @@ function processSceneForCapabilities(
     const currentDirectory = ensureDirectoryChain(directories, root, nodeMap);
     const fileNode = ensureFileNode(segments, fileName, currentDirectory, nodeMap);
 
-    const outcomeKey = mapOutcomeToKey(outcomeCodeToDisplayString(scene.outcome.code)) as keyof ReportOutcomes;
+    const outcomeDisplay = outcomeCodeToDisplayString(scene.outcome.code);
+    const outcomeKey = mapOutcomeToKey(outcomeDisplay) as keyof ReportOutcomes;
 
     fileNode.scenarioCount++;
     fileNode.outcomes[outcomeKey]++;
 
     const executionHistory = buildExecutionHistory(scene, allRuns);
 
-    fileNode.scenarios.push({ name: scene.name, outcome: outcomeCodeToDisplayString(scene.outcome.code), executionHistory });
+    fileNode.scenarios.push({ name: scene.name, outcome: outcomeDisplay, executionHistory });
     if (scene.narrative && !fileNode.narrative) {
         fileNode.narrative = scene.narrative;
     }
@@ -122,9 +123,8 @@ function ensureFileNode(
 }
 
 function buildExecutionHistory(scene: SceneRecord, allRuns: RunData[]): string[] {
-    const scenarioKey = sceneIdentity(scene);
     return allRuns.map(r => {
-        const match = r.scenes.find(s => sceneIdentity(s) === scenarioKey);
+        const match = findHistoricalMatch(scene, r.scenes);
         return match ? outcomeCodeToDisplayString(match.outcome.code) : undefined;
     }).filter(Boolean) as string[];
 }

--- a/packages/html-reporter/src/cli/history/buildHistory.ts
+++ b/packages/html-reporter/src/cli/history/buildHistory.ts
@@ -1,9 +1,6 @@
-import { ExecutionSuccessful } from '@serenity-js/core/model';
-
-import { outcomeCodeToDisplayString } from '../model/outcomes.js';
+import { groupOutcomesByScene } from '../model/groupScenes.js';
 import { resolveRunLabel } from '../model/resolveRunLabel.js';
 import type { RunData } from '../model/RunData.js';
-import { sceneIdentity } from '../model/sceneIdentity.js';
 import type { ReportHistoryEntry } from '../reporting/ReportData.js';
 
 interface DurationStats {
@@ -41,22 +38,6 @@ function extractCiMetadata(run: RunData): CiMetadata {
 function computeRunScore(passRate: number, completeness: number, consistency: number): ReportHistoryEntry['score'] {
     const confidence = Math.round(completeness * 0.3 + passRate * 0.35 + consistency * 0.35);
     return { confidence, passRate, consistency, completeness };
-}
-
-function buildOutcomeMap(runs: RunData[]): Map<string, string[]> {
-    const testOutcomes = new Map<string, string[]>();
-    for (const run of runs) {
-        for (const scene of run.scenes) {
-            const identity = sceneIdentity(scene);
-            if (!testOutcomes.has(identity)) testOutcomes.set(identity, []);
-
-            const effectiveOutcome = (scene.retries > 0 && scene.outcome.code === ExecutionSuccessful.Code)
-                ? 'RETRIED_SUCCESS'
-                : outcomeCodeToDisplayString(scene.outcome.code);
-            testOutcomes.get(identity).push(effectiveOutcome);
-        }
-    }
-    return testOutcomes;
 }
 
 /**
@@ -100,15 +81,15 @@ export function buildHistory(allRuns: RunData[]): ReportHistoryEntry[] {
 export function computeConsistencyAtRun(runs: RunData[]): number {
     if (runs.length < 2) return 100;
 
-    const testOutcomes = buildOutcomeMap(runs);
+    const groups = groupOutcomesByScene(runs);
 
     let totalTests = 0;
     let stableTests = 0;
-    for (const [, outcomes] of testOutcomes) {
-        if (outcomes.length >= 2) {
+    for (const group of groups) {
+        if (group.outcomes.length >= 2) {
             totalTests++;
-            const uniqueOutcomes = new Set(outcomes);
-            if (uniqueOutcomes.size === 1 && !outcomes.includes('RETRIED_SUCCESS')) stableTests++;
+            const uniqueOutcomes = new Set(group.outcomes);
+            if (uniqueOutcomes.size === 1 && !group.outcomes.includes('RETRIED_SUCCESS')) stableTests++;
         }
     }
     return totalTests > 0 ? Math.round((stableTests / totalTests) * 100) : 100;

--- a/packages/html-reporter/src/cli/model/groupScenes.ts
+++ b/packages/html-reporter/src/cli/model/groupScenes.ts
@@ -1,0 +1,51 @@
+import { effectiveOutcome } from './outcomes.js';
+import { resolveRunLabel } from './resolveRunLabel.js';
+import type { RunData } from './RunData.js';
+import { findHistoricalMatch } from './sceneIdentity.js';
+
+/**
+ * A group of outcomes for a single test identity across multiple runs.
+ * The `representative` is the first scene encountered for this identity
+ * and carries the canonical `name`, `source`, `tags`, etc.
+ *
+ * @internal
+ */
+export interface SceneOutcomeGroup {
+    representative: RunData['scenes'][number];
+    outcomes: string[];
+    labels: string[];
+}
+
+/**
+ * Groups scenes across runs by fuzzy-matching identity (2-of-3 on path, line, name).
+ * Each unique test identity produces one group with accumulated outcomes and run labels.
+ *
+ * @internal
+ */
+export function groupOutcomesByScene(runs: RunData[]): SceneOutcomeGroup[] {
+    const groups: SceneOutcomeGroup[] = [];
+    const representatives: RunData['scenes'][number][] = [];
+
+    for (const run of runs) {
+        const runLabel = resolveRunLabel(run);
+        for (const scene of run.scenes) {
+            const match = findHistoricalMatch(scene, representatives);
+            const outcome = effectiveOutcome(scene);
+
+            if (match) {
+                const groupIndex = representatives.indexOf(match);
+                groups[groupIndex].outcomes.push(outcome);
+                groups[groupIndex].labels.push(runLabel);
+            } else {
+                representatives.push(scene);
+                groups.push({
+                    representative: scene,
+                    outcomes: [outcome],
+                    labels: [runLabel],
+                });
+            }
+        }
+    }
+
+    return groups;
+}

--- a/packages/html-reporter/src/cli/model/index.ts
+++ b/packages/html-reporter/src/cli/model/index.ts
@@ -1,5 +1,6 @@
 export * from './classifyConsistencyKind.js';
 export * from './formatSource.js';
+export * from './groupScenes.js';
 export * from './outcomes.js';
 export * from './resolveRunLabel.js';
 export * from './RunData.js';

--- a/packages/html-reporter/src/cli/model/outcomes.ts
+++ b/packages/html-reporter/src/cli/model/outcomes.ts
@@ -69,3 +69,15 @@ export function mapOutcomeToKey(outcome: string): string {
     const map: Record<string, string> = { SUCCESS: 'passed', FAILURE: 'failed', ERROR: 'error', COMPROMISED: 'compromised', PENDING: 'pending', SKIPPED: 'skipped' };
     return map[outcome] || 'error';
 }
+
+/**
+ * Computes the effective outcome label for a scene, treating a retried pass
+ * as a distinct `RETRIED_SUCCESS` signal rather than a plain success.
+ *
+ * @internal
+ */
+export function effectiveOutcome(scene: { retries?: number; outcome: { code: number } }): string {
+    return (scene.retries && scene.retries > 0 && scene.outcome.code === ExecutionSuccessful.Code)
+        ? 'RETRIED_SUCCESS'
+        : outcomeCodeToDisplayString(scene.outcome.code);
+}

--- a/packages/html-reporter/src/cli/model/sceneIdentity.ts
+++ b/packages/html-reporter/src/cli/model/sceneIdentity.ts
@@ -75,6 +75,25 @@ export function sceneIdentityWithinRun(scenes: SceneShape[]): (scene: SceneShape
 }
 
 /**
+ * Computes a match score and tiebreaker for two scenes.
+ * Score counts matching fields (0–3); tiebreaker encodes which fields matched
+ * so that path+name (6) > path+line (5) > line+name (3).
+ */
+function matchScore(
+    a: SceneShape,
+    b: SceneShape,
+): { score: number; tiebreaker: number } {
+    const pathMatch = a.source.path === b.source.path;
+    const lineMatch = a.source.line === b.source.line;
+    const nameMatch = a.name === b.name;
+
+    return {
+        score: +pathMatch + +lineMatch + +nameMatch,
+        tiebreaker: (pathMatch ? 4 : 0) + (nameMatch ? 2 : 0) + (lineMatch ? 1 : 0),
+    };
+}
+
+/**
  * Finds the best-matching candidate for a scene using 2-of-3 fuzzy matching
  * on path, line, and name. Used for cross-run history matching where a test
  * may have been renamed (path+line still match) or moved within a file
@@ -107,20 +126,9 @@ export function findHistoricalMatch<T extends SceneShape>(
             continue;
         }
 
-        const pathMatch = candidate.source.path === scene.source.path;
-        const lineMatch = candidate.source.line === scene.source.line;
-        const nameMatch = candidate.name === scene.name;
+        const { score, tiebreaker } = matchScore(scene, candidate);
 
-        const score = (pathMatch ? 1 : 0) + (lineMatch ? 1 : 0) + (nameMatch ? 1 : 0);
-
-        if (score < 2) {
-            continue;
-        }
-
-        // Tiebreaker: path+name (6) > path+line (5) > line+name (3)
-        const tiebreaker = (pathMatch ? 4 : 0) + (nameMatch ? 2 : 0) + (lineMatch ? 1 : 0);
-
-        if (score > bestScore || (score === bestScore && tiebreaker > bestTiebreaker)) {
+        if (score >= 2 && (score > bestScore || (score === bestScore && tiebreaker > bestTiebreaker))) {
             bestScore = score;
             bestTiebreaker = tiebreaker;
             bestMatch = candidate;

--- a/packages/html-reporter/src/cli/model/sceneIdentity.ts
+++ b/packages/html-reporter/src/cli/model/sceneIdentity.ts
@@ -37,3 +37,95 @@ export function sceneIdentity(scene: { source: { path: string; line: number }; n
     const discriminator = tagDiscriminator(scene.tags);
     return discriminator ? `${ base }@${ discriminator }` : base;
 }
+
+type SceneShape = { source: { path: string; line: number }; name: string; tags: TagRecord[] };
+
+/**
+ * Creates a collision-aware identity function for scenes within a single run.
+ *
+ * When multiple scenes share the same `path:line` (and the same tag discriminator),
+ * such as tests generated dynamically via a `for` loop, the standard `sceneIdentity`
+ * produces identical keys for distinct tests. This function detects those collisions
+ * and appends the scenario name to disambiguate.
+ *
+ * Non-colliding scenes retain their original `path:line` identity, preserving
+ * backwards-compatible history matching for renamed tests.
+ *
+ * @param scenes - All scenes in the run
+ * @returns A function that produces a unique identity for each scene
+ *
+ * @internal
+ */
+export function sceneIdentityWithinRun(scenes: SceneShape[]): (scene: SceneShape) => string {
+    const baseIdentityCounts = new Map<string, number>();
+    for (const scene of scenes) {
+        const base = sceneIdentity(scene);
+        baseIdentityCounts.set(base, (baseIdentityCounts.get(base) || 0) + 1);
+    }
+
+    return (scene: SceneShape): string => {
+        const base = sceneIdentity(scene);
+        if (baseIdentityCounts.get(base) > 1 && scene.source.line) {
+            const discriminator = tagDiscriminator(scene.tags);
+            const nameQualified = `${ scene.source.path }:${ scene.source.line }:${ scene.name }`;
+            return discriminator ? `${ nameQualified }@${ discriminator }` : nameQualified;
+        }
+        return base;
+    };
+}
+
+/**
+ * Finds the best-matching candidate for a scene using 2-of-3 fuzzy matching
+ * on path, line, and name. Used for cross-run history matching where a test
+ * may have been renamed (path+line still match) or moved within a file
+ * (path+name still match).
+ *
+ * The tag discriminator (module, browser, project, platform) is a hard gate:
+ * candidates with a different discriminator are excluded before scoring.
+ *
+ * When multiple candidates score equally, tiebreaking prefers:
+ *   3/3 > path+name (6) > path+line (5) > line+name (3)
+ *
+ * @param scene      - The scene to find a historical match for
+ * @param candidates - All scenes from a historical run
+ * @returns The best-matching candidate, or `undefined` if no candidate scores ≥ 2
+ *
+ * @internal
+ */
+export function findHistoricalMatch<T extends SceneShape>(
+    scene: SceneShape,
+    candidates: T[],
+): T | undefined {
+    const sceneDiscriminator = tagDiscriminator(scene.tags);
+
+    let bestMatch: T | undefined;
+    let bestScore = 0;
+    let bestTiebreaker = 0;
+
+    for (const candidate of candidates) {
+        if (tagDiscriminator(candidate.tags) !== sceneDiscriminator) {
+            continue;
+        }
+
+        const pathMatch = candidate.source.path === scene.source.path;
+        const lineMatch = candidate.source.line === scene.source.line;
+        const nameMatch = candidate.name === scene.name;
+
+        const score = (pathMatch ? 1 : 0) + (lineMatch ? 1 : 0) + (nameMatch ? 1 : 0);
+
+        if (score < 2) {
+            continue;
+        }
+
+        // Tiebreaker: path+name (6) > path+line (5) > line+name (3)
+        const tiebreaker = (pathMatch ? 4 : 0) + (nameMatch ? 2 : 0) + (lineMatch ? 1 : 0);
+
+        if (score > bestScore || (score === bestScore && tiebreaker > bestTiebreaker)) {
+            bestScore = score;
+            bestTiebreaker = tiebreaker;
+            bestMatch = candidate;
+        }
+    }
+
+    return bestMatch;
+}

--- a/packages/html-reporter/src/index.ts
+++ b/packages/html-reporter/src/index.ts
@@ -25,6 +25,7 @@ export type {
     ReportSystemContext,
     ReportTag,
 } from './cli/reporting/ReportData.js';
+export type { ReportSummaryJson } from './cli/reporting/ReportSummaryJson.js';
 
 export default function create(config: HtmlReporterConfig = {}): StageCrewMemberBuilder<HtmlReporter> {
     return HtmlReporter.fromJSON(config);


### PR DESCRIPTION
Introduce findHistoricalMatch with 2-of-3 matching on path, line, and name for cross-run scenario correlation. This makes history resilient to both renames (path+line still match) and moves within a file (path+name still match).

Migrate all six cross-run matching call sites from exact sceneIdentity key lookup to findHistoricalMatch, and extract shared utilities:
- effectiveOutcome() centralises retried-pass classification
- groupOutcomesByScene() is the shared cross-run grouping primitive
- findHistoricalMatch client adapter in app/utils/navigation.ts

Also:
- Assign collision-aware scenario IDs via sceneIdentityWithinRun so for-loop-generated tests at the same source line get distinct URLs and history
- Export ReportSummaryJson type from the package root
- Add integration tests for dynamic test navigation and history