### PR TITLE
fix(html-reporter): fix scenario lookup when browser version drifts between CI runs

### DIFF
--- a/integration/html-reporter/spec/scenarios/browser-version-drift.spec.ts
+++ b/integration/html-reporter/spec/scenarios/browser-version-drift.spec.ts
@@ -1,0 +1,42 @@
+import { Ensure, includes } from '@serenity-js/assertions';
+import { notes } from '@serenity-js/core';
+import { Navigate, Page } from '@serenity-js/web';
+
+import { describe, it } from '../../src';
+
+describe('Test Scenarios', () => {
+
+    describe('Browser Version Drift', () => {
+
+        it('finds a scenario when the URL contains a stale browser version', async ({ actor, scenariosView, scenarioDetailView }) => {
+            const scenarioName = 'Login should log in with valid credentials';
+
+            // Navigate to the scenario detail via the normal flow
+            await actor.attemptsTo(
+                scenariosView.open(),
+                scenariosView.find(scenarioName),
+                scenariosView.scenarioCalled(scenarioName).viewDetails(),
+
+                // Verify we landed on the correct detail page
+                Ensure.that(scenarioDetailView.scenarioName(), includes(scenarioName)),
+
+                // Capture the current URL (has the correct browser version)
+                notes().set('originalUrl', Page.current().url().href),
+            );
+
+            // Replace the browser version with a stale one to simulate
+            // a bookmarked URL or a consistency card link from an older run
+            const staleUrl = await actor.answer(
+                notes().get('originalUrl').as((url: string) =>
+                    url.replace(/browser=chromium%20[\d.]+/, 'browser=chromium%20100.0.0.0')
+                ),
+            );
+
+            // The stale browser version should still resolve to the correct scenario
+            await actor.attemptsTo(
+                Navigate.to(staleUrl),
+                Ensure.that(scenarioDetailView.scenarioName(), includes(scenarioName)),
+            );
+        });
+    });
+});

--- a/packages/html-reporter/app/hooks/scenarioMatchingStrategies.ts
+++ b/packages/html-reporter/app/hooks/scenarioMatchingStrategies.ts
@@ -1,0 +1,72 @@
+import type { ReportScenario, ReportScenarioTag } from '../../src/cli/reporting/ReportData.js';
+
+function browserName(tag: string | null): string | null {
+    if (!tag) return null;
+    const spaceIndex = tag.indexOf(' ');
+    return spaceIndex === -1 ? tag : tag.slice(0, spaceIndex);
+}
+
+function filterByTags(scenarios: ReportScenario[], browserString: string | null, projectString: string | null, platformString: string | null, relaxBrowser: boolean): ReportScenario[] {
+    const matchesTag = (tags: ReportScenarioTag[], type: string, value: string | null): boolean =>
+        !value || tags.some(t => t.type === type && t.name === value);
+
+    const matchesBrowser = (tags: ReportScenarioTag[], value: string | null): boolean => {
+        if (!value) return true;
+        return relaxBrowser
+            ? tags.some(t => t.type === 'browser' && browserName(t.name) === browserName(value))
+            : tags.some(t => t.type === 'browser' && t.name === value);
+    };
+
+    return scenarios.filter(s => {
+        const tags = s.tags || [];
+        return matchesBrowser(tags, browserString)
+            && matchesTag(tags, 'project', projectString)
+            && matchesTag(tags, 'platform', platformString);
+    });
+}
+
+export function parseScenarioParameters(scenarioId: string): {
+    cleanId: string;
+    runString: string | null;
+    attemptString: string | null;
+    projectString: string | null;
+    browserString: string | null;
+    platformString: string | null;
+} {
+    const cleanId = scenarioId.split('?')[0];
+    const params = scenarioId.includes('?') ? new URLSearchParams(scenarioId.split('?')[1]) : null;
+    return {
+        cleanId,
+        runString: params?.get('run') ?? null,
+        attemptString: params?.get('attempt') ?? null,
+        projectString: params?.get('project') ?? null,
+        browserString: params?.get('browser') ?? null,
+        platformString: params?.get('platform') ?? null,
+    };
+}
+
+export function findMatchingScenario(
+    scenarios: ReportScenario[], cleanId: string, projectString: string | null, browserString: string | null, platformString: string | null,
+): ReportScenario | null {
+    const decoded = decodeURIComponent(cleanId);
+
+    const findById = (candidates: ReportScenario[]): ReportScenario | undefined =>
+        candidates.find(s => s.id === decoded)
+        ?? candidates.find(s => {
+            const sourceKey = s.source.line
+                ? s.source.path + ':' + s.source.line
+                : s.source.path + ':' + s.name;
+            return sourceKey === decoded;
+        });
+
+    // Try exact tag match first, then fall back to browser-name-only matching
+    // to handle version drift between CI runs, bookmarked URLs, and consistency card links
+    const exactCandidates = filterByTags(scenarios, browserString, projectString, platformString, false);
+    const relaxedCandidates = browserString
+        ? filterByTags(scenarios, browserString, projectString, platformString, true)
+        : [];
+
+    return findById(exactCandidates)
+        ?? findById(relaxedCandidates)
+        ?? null;
+}

--- a/packages/html-reporter/app/hooks/useScenarioDetail.ts
+++ b/packages/html-reporter/app/hooks/useScenarioDetail.ts
@@ -106,6 +106,12 @@ function parseScenarioParameters(scenarioId: string) {
     };
 }
 
+function browserName(tag: string | null): string | null {
+    if (!tag) return null;
+    const spaceIndex = tag.indexOf(' ');
+    return spaceIndex === -1 ? tag : tag.slice(0, spaceIndex);
+}
+
 function findMatchingScenario(
     scenarios: ReportScenario[], cleanId: string, projectString: string | null, browserString: string | null, platformString: string | null,
 ): ReportScenario | null {
@@ -114,23 +120,45 @@ function findMatchingScenario(
     const matchesTag = (tags: ReportScenarioTag[], type: string, value: string | null): boolean =>
         !value || tags.some(t => t.type === type && t.name === value);
 
-    const candidates = scenarios.filter(s => {
+    const matchesBrowserName = (tags: ReportScenarioTag[], value: string | null): boolean =>
+        !value || tags.some(t => t.type === 'browser' && browserName(t.name) === browserName(value));
+
+    const findById = (candidates: ReportScenario[]): ReportScenario | undefined =>
+        candidates.find(s => s.id === decoded)
+        ?? candidates.find(s => {
+            const sourceKey = s.source.line
+                ? s.source.path + ':' + s.source.line
+                : s.source.path + ':' + s.name;
+            return sourceKey === decoded;
+        });
+
+    // Try exact tag match first
+    const exactCandidates = scenarios.filter(s => {
         const tags = s.tags || [];
         return matchesTag(tags, 'browser', browserString)
             && matchesTag(tags, 'project', projectString)
             && matchesTag(tags, 'platform', platformString);
     });
 
-    // First: try exact match on collision-aware id
-    // Fallback: match by source key (backward compatible with old bookmarked URLs)
-    return candidates.find(s => s.id === decoded)
-        ?? candidates.find(s => {
-            const sourceKey = s.source.line
-                ? s.source.path + ':' + s.source.line
-                : s.source.path + ':' + s.name;
-            return sourceKey === decoded;
-        })
-        ?? null;
+    const exactMatch = findById(exactCandidates);
+    if (exactMatch) {
+        return exactMatch;
+    }
+
+    // Fallback: match browser by name only (e.g. "chromium" matches "chromium 152.0.7977.82")
+    // Handles browser version drift between CI runs, bookmarked URLs, and consistency card links
+    if (browserString) {
+        const relaxedCandidates = scenarios.filter(s => {
+            const tags = s.tags || [];
+            return matchesBrowserName(tags, browserString)
+                && matchesTag(tags, 'project', projectString)
+                && matchesTag(tags, 'platform', platformString);
+        });
+
+        return findById(relaxedCandidates) ?? null;
+    }
+
+    return null;
 }
 
 function resolveScenarioViewData(scenario: ReportScenario, runIndex: number | null, activeAttempt: number, history: ReportHistoryEntry[]) {

--- a/packages/html-reporter/app/hooks/useScenarioDetail.ts
+++ b/packages/html-reporter/app/hooks/useScenarioDetail.ts
@@ -112,16 +112,29 @@ function browserName(tag: string | null): string | null {
     return spaceIndex === -1 ? tag : tag.slice(0, spaceIndex);
 }
 
+function filterByTags(scenarios: ReportScenario[], browserString: string | null, projectString: string | null, platformString: string | null, relaxBrowser: boolean): ReportScenario[] {
+    const matchesTag = (tags: ReportScenarioTag[], type: string, value: string | null): boolean =>
+        !value || tags.some(t => t.type === type && t.name === value);
+
+    const matchesBrowser = (tags: ReportScenarioTag[], value: string | null): boolean => {
+        if (!value) return true;
+        return relaxBrowser
+            ? tags.some(t => t.type === 'browser' && browserName(t.name) === browserName(value))
+            : tags.some(t => t.type === 'browser' && t.name === value);
+    };
+
+    return scenarios.filter(s => {
+        const tags = s.tags || [];
+        return matchesBrowser(tags, browserString)
+            && matchesTag(tags, 'project', projectString)
+            && matchesTag(tags, 'platform', platformString);
+    });
+}
+
 function findMatchingScenario(
     scenarios: ReportScenario[], cleanId: string, projectString: string | null, browserString: string | null, platformString: string | null,
 ): ReportScenario | null {
     const decoded = decodeURIComponent(cleanId);
-
-    const matchesTag = (tags: ReportScenarioTag[], type: string, value: string | null): boolean =>
-        !value || tags.some(t => t.type === type && t.name === value);
-
-    const matchesBrowserName = (tags: ReportScenarioTag[], value: string | null): boolean =>
-        !value || tags.some(t => t.type === 'browser' && browserName(t.name) === browserName(value));
 
     const findById = (candidates: ReportScenario[]): ReportScenario | undefined =>
         candidates.find(s => s.id === decoded)
@@ -132,33 +145,16 @@ function findMatchingScenario(
             return sourceKey === decoded;
         });
 
-    // Try exact tag match first
-    const exactCandidates = scenarios.filter(s => {
-        const tags = s.tags || [];
-        return matchesTag(tags, 'browser', browserString)
-            && matchesTag(tags, 'project', projectString)
-            && matchesTag(tags, 'platform', platformString);
-    });
+    // Try exact tag match first, then fall back to browser-name-only matching
+    // to handle version drift between CI runs, bookmarked URLs, and consistency card links
+    const exactCandidates = filterByTags(scenarios, browserString, projectString, platformString, false);
+    const relaxedCandidates = browserString
+        ? filterByTags(scenarios, browserString, projectString, platformString, true)
+        : [];
 
-    const exactMatch = findById(exactCandidates);
-    if (exactMatch) {
-        return exactMatch;
-    }
-
-    // Fallback: match browser by name only (e.g. "chromium" matches "chromium 152.0.7977.82")
-    // Handles browser version drift between CI runs, bookmarked URLs, and consistency card links
-    if (browserString) {
-        const relaxedCandidates = scenarios.filter(s => {
-            const tags = s.tags || [];
-            return matchesBrowserName(tags, browserString)
-                && matchesTag(tags, 'project', projectString)
-                && matchesTag(tags, 'platform', platformString);
-        });
-
-        return findById(relaxedCandidates) ?? null;
-    }
-
-    return null;
+    return findById(exactCandidates)
+        ?? findById(relaxedCandidates)
+        ?? null;
 }
 
 function resolveScenarioViewData(scenario: ReportScenario, runIndex: number | null, activeAttempt: number, history: ReportHistoryEntry[]) {

--- a/packages/html-reporter/app/hooks/useScenarioDetail.ts
+++ b/packages/html-reporter/app/hooks/useScenarioDetail.ts
@@ -1,7 +1,8 @@
 import { useEffect, useMemo, useRef, useState } from 'preact/hooks';
 
-import type { ReportActivity, ReportAttempt, ReportError, ReportExecutionHistoryEntry, ReportHistoryEntry, ReportScenario, ReportScenarioTag } from '../../src/cli/reporting/ReportData.js';
+import type { ReportActivity, ReportAttempt, ReportError, ReportExecutionHistoryEntry, ReportHistoryEntry, ReportScenario } from '../../src/cli/reporting/ReportData.js';
 import { resolveRunIndex, useHashHistory } from '../utils/index.js';
+import { findMatchingScenario, parseScenarioParameters } from './scenarioMatchingStrategies.js';
 
 export interface ScenarioDetailState {
     scenario: ReportScenario | null;
@@ -91,70 +92,6 @@ export function useScenarioDetail(scenarioId: string, scenarios: ReportScenario[
         scenario, runIndex, activeAttempt, setActiveAttempt,
         ...viewData,
     };
-}
-
-function parseScenarioParameters(scenarioId: string) {
-    const cleanId = scenarioId.split('?')[0];
-    const params = scenarioId.includes('?') ? new URLSearchParams(scenarioId.split('?')[1]) : null;
-    return {
-        cleanId,
-        runString: params?.get('run') ?? null,
-        attemptString: params?.get('attempt') ?? null,
-        projectString: params?.get('project') ?? null,
-        browserString: params?.get('browser') ?? null,
-        platformString: params?.get('platform') ?? null,
-    };
-}
-
-function browserName(tag: string | null): string | null {
-    if (!tag) return null;
-    const spaceIndex = tag.indexOf(' ');
-    return spaceIndex === -1 ? tag : tag.slice(0, spaceIndex);
-}
-
-function filterByTags(scenarios: ReportScenario[], browserString: string | null, projectString: string | null, platformString: string | null, relaxBrowser: boolean): ReportScenario[] {
-    const matchesTag = (tags: ReportScenarioTag[], type: string, value: string | null): boolean =>
-        !value || tags.some(t => t.type === type && t.name === value);
-
-    const matchesBrowser = (tags: ReportScenarioTag[], value: string | null): boolean => {
-        if (!value) return true;
-        return relaxBrowser
-            ? tags.some(t => t.type === 'browser' && browserName(t.name) === browserName(value))
-            : tags.some(t => t.type === 'browser' && t.name === value);
-    };
-
-    return scenarios.filter(s => {
-        const tags = s.tags || [];
-        return matchesBrowser(tags, browserString)
-            && matchesTag(tags, 'project', projectString)
-            && matchesTag(tags, 'platform', platformString);
-    });
-}
-
-function findMatchingScenario(
-    scenarios: ReportScenario[], cleanId: string, projectString: string | null, browserString: string | null, platformString: string | null,
-): ReportScenario | null {
-    const decoded = decodeURIComponent(cleanId);
-
-    const findById = (candidates: ReportScenario[]): ReportScenario | undefined =>
-        candidates.find(s => s.id === decoded)
-        ?? candidates.find(s => {
-            const sourceKey = s.source.line
-                ? s.source.path + ':' + s.source.line
-                : s.source.path + ':' + s.name;
-            return sourceKey === decoded;
-        });
-
-    // Try exact tag match first, then fall back to browser-name-only matching
-    // to handle version drift between CI runs, bookmarked URLs, and consistency card links
-    const exactCandidates = filterByTags(scenarios, browserString, projectString, platformString, false);
-    const relaxedCandidates = browserString
-        ? filterByTags(scenarios, browserString, projectString, platformString, true)
-        : [];
-
-    return findById(exactCandidates)
-        ?? findById(relaxedCandidates)
-        ?? null;
 }
 
 function resolveScenarioViewData(scenario: ReportScenario, runIndex: number | null, activeAttempt: number, history: ReportHistoryEntry[]) {

--- a/packages/html-reporter/spec/cli/HtmlReporter.spec.ts
+++ b/packages/html-reporter/spec/cli/HtmlReporter.spec.ts
@@ -37,6 +37,7 @@ import {
 } from '@serenity-js/core/model';
 import { createFsFromVolume, Volume } from 'memfs';
 
+import corePkg from '../../../core/package.json' with { type: 'json' };
 import pkg from '../../package.json' with { type: 'json' };
 import { SingleSourceAggregator } from '../../src/cli/aggregation/SingleSourceAggregator.js';
 import type { RuntimeContext } from '../../src/cli/collection/CiDetector.js';
@@ -318,7 +319,7 @@ test.describe('HtmlReporter', () => {
             expect(content).toHaveProperty('systemContext');
             expect(content.systemContext).toHaveProperty('nodeVersion', process.version);
             expect(content.systemContext.os).toHaveProperty('arch');
-            expect(content.systemContext).toHaveProperty('serenityVersion', pkg.version);
+            expect(content.systemContext).toHaveProperty('serenityVersion', corePkg.version);
             expect(content.systemContext.runtime).toHaveProperty('provider');
         });
 

--- a/packages/html-reporter/spec/cli/HtmlReporter.spec.ts
+++ b/packages/html-reporter/spec/cli/HtmlReporter.spec.ts
@@ -37,8 +37,7 @@ import {
 } from '@serenity-js/core/model';
 import { createFsFromVolume, Volume } from 'memfs';
 
-import corePkg from '../../../core/package.json' with { type: 'json' };
-import pkg from '../../package.json' with { type: 'json' };
+import corePackage from '../../../core/package.json' with { type: 'json' };
 import { SingleSourceAggregator } from '../../src/cli/aggregation/SingleSourceAggregator.js';
 import type { RuntimeContext } from '../../src/cli/collection/CiDetector.js';
 import type { ExecutionContext } from '../../src/cli/collection/ExecutionContext.js';
@@ -319,7 +318,7 @@ test.describe('HtmlReporter', () => {
             expect(content).toHaveProperty('systemContext');
             expect(content.systemContext).toHaveProperty('nodeVersion', process.version);
             expect(content.systemContext.os).toHaveProperty('arch');
-            expect(content.systemContext).toHaveProperty('serenityVersion', corePkg.version);
+            expect(content.systemContext).toHaveProperty('serenityVersion', corePackage.version);
             expect(content.systemContext.runtime).toHaveProperty('provider');
         });
 


### PR DESCRIPTION
Clicking a flaky test in the Consistency dashboard card navigated to "Test scenario not found" on the published report at serenity-js.github.io. The consistency card's representative came from an older CI run with chrome 152.0.7977.54, but the current run had chrome 152.0.7977.82. The scenario detail route filtered candidates by exact browser tag match, so no candidate survived the filter.

## Changes
  
### Browser version fallback (app/hooks/useScenarioDetail.ts)

`findMatchingScenario()` now uses two-tier browser matching:

1. Try exact browser tag match (preserves precision for fresh URLs)
2. If no match, fall back to browser-name-only matching — compare just "chromium" or "chrome", ignoring the version suffix

This handles browser auto-updates between CI runs, bookmarked URLs with stale versions, and consistency card links where the representative comes from an older run.

### Serenity version test fix (spec/cli/HtmlReporter.spec.ts)

The "includes system context in db.json" unit test compared `serenityVersion` against the html-reporter's package.json version. The production code reads this from `@serenity-js/core`. When a release bumps html-reporter but not core (no qualifying commits), the versions diverge. Fixed to compare against `core/package.json` instead.