### PR TITLE
docs(web): enhance JSDoc for story fixture and PageElement.createAdapter

### DIFF
--- a/packages/html-reporter/README.md
+++ b/packages/html-reporter/README.md
@@ -44,7 +44,7 @@ Add the reporter to your Serenity/JS crew configuration.
 
 ### Playwright Test
 
-```typescript
+```ts
 // playwright.config.ts
 import { defineConfig } from '@playwright/test';
 import type { SerenityFixtures, SerenityWorkerFixtures } from '@serenity-js/playwright-test';
@@ -67,7 +67,7 @@ Learn more about using [Serenity/JS with Playwright Test](https://serenity-js.or
 
 ### WebdriverIO
 
-```typescript
+```ts
 // wdio.conf.ts
 export const config = {
     framework: '@serenity-js/webdriverio',
@@ -86,7 +86,7 @@ Learn more about using [Serenity/JS with WebdriverIO](https://serenity-js.org/ha
 
 ### Cucumber, Mocha, or Jasmine
 
-```typescript
+```ts
 import { configure } from '@serenity-js/core';
 
 configure({
@@ -133,7 +133,7 @@ All options are optional. See the [`HtmlReporterConfig` API reference](https://s
 
 The reporter auto-detects CI metadata from environment variables (GitHub Actions, GitLab CI, Jenkins, CircleCI). Use the `ci` option when running outside CI or when auto-detection doesn't match your setup:
 
-```typescript
+```ts
 ['@serenity-js/html-reporter', {
     outputDirectory: './reports/serenity-js',
     ci: {

--- a/packages/html-reporter/spec/app/README.md
+++ b/packages/html-reporter/spec/app/README.md
@@ -22,7 +22,7 @@ template/components/*.ts      ← Preact components under test
 An interaction object is a class that receives the mounted component's root element
 and exposes Questions (for reading state) and Tasks (for performing actions):
 
-```typescript
+```ts
 // src/SearchInput.serenity.ts
 import type { Answerable, QuestionAdapter } from '@serenity-js/core';
 import { Task, the } from '@serenity-js/core';
@@ -67,7 +67,7 @@ export class SearchInput<NET> {
 
 ## Writing a Component Test
 
-```typescript
+```ts
 // spec/components/SearchInput.spec.ts
 import { Ensure, equals, isFalse } from '@serenity-js/assertions';
 
@@ -117,7 +117,7 @@ The `mount` fixture handles:
 3. Navigating Playwright to the page
 4. Instantiating the interaction object with a `PageElement` pointing to the rendered component
 
-```typescript
+```ts
 const searchInput = await mount<SearchInput<unknown>>({
     component: 'SearchInput',          // Export name from the template module
     importPath: './components/SearchInput', // Import path relative to template/

--- a/packages/playwright-test/src/api/serenity-fixtures.ts
+++ b/packages/playwright-test/src/api/serenity-fixtures.ts
@@ -414,7 +414,7 @@ export interface SerenityFixtures {
      * ```typescript
      * import { Ensure, equals } from '@serenity-js/assertions'
      * import { describe, it } from '@serenity-js/playwright-test'
-     * import { UserCard } from './UserCard.io'
+     * import { UserCard } from './UserCard.serenity'
      *
      * describe('UserCard', () => {
      *
@@ -434,7 +434,7 @@ export interface SerenityFixtures {
      * @param props - Optional serializable props to pass to the story.
      *
      * #### Learn more
-     * - [Component testing with Playwright Test](https://serenity-js.org/handbook/test-runners/playwright-test/component-testing/)
+     * - [Component testing with Serenity/JS and Playwright Test](https://serenity-js.org/handbook/test-runners/playwright-test/component-testing/)
      * - [Playwright component testing](https://playwright.dev/docs/test-components)
      */
     story: (storyPath: string, props?: Record<string, any>) => QuestionAdapter<PageElement<Locator>>;

--- a/packages/web/src/screenplay/models/PageElement.ts
+++ b/packages/web/src/screenplay/models/PageElement.ts
@@ -78,10 +78,31 @@ export abstract class PageElement<Native_Element_Type = any> implements Optional
      * Wraps any {@link Answerable}<{@link PageElement}> in a {@link PageElementAdapter},
      * providing `.element()` and `.elements()` for scoped child element lookups.
      *
-     * Used by {@link InteractionObject} to ensure the root element supports
-     * fluent child element access regardless of how it was constructed.
+     * Use this in Interaction Object constructors to ensure the root element supports
+     * fluent child element access regardless of whether it was constructed from a resolved
+     * {@link PageElement} (via the [`story` fixture](https://serenity-js.org/handbook/test-runners/playwright-test/component-testing/))
+     * or a deferred {@link QuestionAdapter}<{@link PageElement}> (via `PageElement.located()`):
+     *
+     * ```ts
+     * import type { Answerable } from '@serenity-js/core'
+     * import { By, PageElement } from '@serenity-js/web'
+     *
+     * class UserCard {
+     *     private readonly rootElement;
+     *
+     *     constructor(rootElement: Answerable<PageElement>) {
+     *         this.rootElement = PageElement.createAdapter(rootElement);
+     *     }
+     *
+     *     name = () =>
+     *         this.rootElement.element(By.css('.name')).text()
+     *             .describedAs('user name');
+     * }
+     * ```
      *
      * @param element
+     *
+     * @group Models
      */
     static createAdapter<NET>(element: Answerable<PageElement<NET>>): PageElementAdapter<NET> {
         return Question.about(`${ element }`,


### PR DESCRIPTION
- Fix stale UserCard.io import in story fixture JSDoc (now .serenity)
- Add IO constructor example and component testing link to PageElement.createAdapter() JSDoc